### PR TITLE
Mirrors, DHCP and TAP setup

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -33,7 +33,9 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get -y install --no-install-recommends so
 RUN DEBIAN_FRONTEND=noninteractive apt-get -y install ca-certificates \
     curl \
     gnupg \
-    lsb-release
+    lsb-release \
+    uml-utilities \
+    isc-dhcp-server
 
 # Install latest docker
 RUN sudo mkdir -p /etc/apt/keyrings

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,7 +69,7 @@ jobs:
           ovmf.qcow2
         time xz -v -8 -T0 ${ARC}
     - name: Upload files
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with: 
         name: eclipse-leda-qemu-x86_64.tar.xz
         if-no-files-found: error
@@ -119,7 +119,7 @@ jobs:
           sdv-rauc-bundle-raspberrypi4-64.raucb
         time xz -v -1 -T0 ${ARC}
     - name: Upload files
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with: 
         name: eclipse-leda-raspberrypi.tar.xz
         if-no-files-found: error

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,9 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v3
     - name: Install tools
-      run: sudo apt-get install -y --no-install-recommends socat file gawk wget git diffstat unzip texinfo gcc build-essential chrpath socat cpio python3 python3-pip python3-pexpect xz-utils debianutils iputils-ping python3-git python3-jinja2 libegl1-mesa libsdl1.2-dev pylint xterm python3-subunit mesa-common-dev zstd liblz4-tool tmux mc skopeo fdisk ruby-full jq libvirt-clients libvirt-daemon-system qemu-system-x86 qemu-system-arm qemu-kvm squashfs-tools rauc python3-newt ca-certificates curl gnupg lsb-release
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y --no-install-recommends socat file gawk wget git diffstat unzip texinfo gcc build-essential chrpath socat cpio python3 python3-pip python3-pexpect xz-utils debianutils iputils-ping python3-git python3-jinja2 libegl1-mesa libsdl1.2-dev pylint xterm python3-subunit mesa-common-dev zstd liblz4-tool tmux mc skopeo fdisk ruby-full jq libvirt-clients libvirt-daemon-system qemu-system-x86 qemu-system-arm qemu-kvm squashfs-tools rauc python3-newt ca-certificates curl gnupg lsb-release
     - name: Install kas
       run: sudo pip3 install kas
     - name: Start BitBake Hash Equivalence Server

--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ meta-rauc-community/
 meta-rauc/
 meta-raspberrypi
 meta-kanto/
+meta-leda/
 meta-virtualization/
 poky/
 

--- a/.gitignore
+++ b/.gitignore
@@ -43,12 +43,23 @@ build/
 meta-openembedded/
 meta-rauc-community/
 meta-rauc/
+meta-raspberrypi
+meta-kanto/
 meta-virtualization/
 poky/
 
 # Remote sstate-cache on Azure Storage
 azure-sstate-cache/
+azure-downloads-cache/
 bitbake/
 
 # BitBake Hash Equivalence Server database
 hashserv.db
+
+# DHCP Leases
+scripts/dhcp.pid
+scripts/dhcpc.leases
+scripts/dhcpc.leases~
+
+# Qemu Disk Images - QCOW2
+*.qcow2

--- a/kas/mirrors.yaml
+++ b/kas/mirrors.yaml
@@ -24,7 +24,7 @@ local_conf_header:
     BB_HASHSERVE = "20.238.216.74:1234"
     MIRROR_SERVER = "https://sdvyocto.blob.core.windows.net/downloads/"
     SSTATE_MIRRORS = "file://.* https://sdvyocto.blob.core.windows.net/yocto-sstate-cache/sstate-cache/PATH"
-    BB_FETCH_PREMIRRORONLY = "1"
+    BB_FETCH_PREMIRRORONLY = "0"
     INHERIT += "own-mirrors"
     SOURCE_MIRROR_URL = "${MIRROR_SERVER}"
     UNINATIVE_URL = "${MIRROR_SERVER}"

--- a/scripts/dhcp.conf
+++ b/scripts/dhcp.conf
@@ -1,0 +1,60 @@
+# /********************************************************************************
+# * Copyright (c) 2022 Contributors to the Eclipse Foundation
+# *
+# * See the NOTICE file(s) distributed with this work for additional
+# * information regarding copyright ownership.
+# *
+# * This program and the accompanying materials are made available under the
+# * terms of the Apache License 2.0 which is available at
+# * https://www.apache.org/licenses/LICENSE-2.0
+# *
+# * SPDX-License-Identifier: Apache-2.0
+# ********************************************************************************/
+#
+# dhcpd.conf
+#
+# Sample configuration file for ISC dhcpd
+#
+
+default-lease-time 60;
+max-lease-time 720;
+
+subnet 192.168.7.0 netmask 255.255.255.0 {
+  option domain-name-servers 1.1.1.1, 8.8.8.8;
+  option domain-name "leda";
+}
+
+#
+# A couple of pre-defined IP addresses for different MAC adresses
+# which are used by the run-image.sh script
+#
+
+host leda1 {
+  hardware ethernet 52:54:00:12:34:01;
+  fixed-address 192.168.7.201;
+  option routers 192.168.7.101;
+}
+
+host leda2 {
+  hardware ethernet 52:54:00:12:34:02;
+  fixed-address 192.168.7.202;
+  option routers 192.168.7.102;
+}
+
+host leda3 {
+  hardware ethernet 52:54:00:12:34:03;
+  fixed-address 192.168.7.203;
+  option routers 192.168.7.103;
+}
+
+host leda4 {
+  hardware ethernet 52:54:00:12:34:04;
+  fixed-address 192.168.7.204;
+  option routers 192.168.7.104;
+}
+
+host leda5 {
+  hardware ethernet 52:54:00:12:34:05;
+  fixed-address 192.168.7.205;
+  option routers 192.168.7.105;
+}

--- a/scripts/run-dhcp.sh
+++ b/scripts/run-dhcp.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# /********************************************************************************
+# * Copyright (c) 2022 Contributors to the Eclipse Foundation
+# *
+# * See the NOTICE file(s) distributed with this work for additional
+# * information regarding copyright ownership.
+# *
+# * This program and the accompanying materials are made available under the
+# * terms of the Apache License 2.0 which is available at
+# * https://www.apache.org/licenses/LICENSE-2.0
+# *
+# * SPDX-License-Identifier: Apache-2.0
+# ********************************************************************************/
+# Run a DHCP service for the TAP networks
+if [ "$EUID" -ne 0 ]
+  then echo "Please run as root"
+  exit
+fi
+
+touch dhcpc.leases
+sudo dhcpd -4 -cf dhcp.conf -f -d -lf dhcpc.leases -pf dhcp.pid tap1 tap2 tap3 tap4 tap5

--- a/scripts/run-image.sh
+++ b/scripts/run-image.sh
@@ -11,21 +11,52 @@
 # *
 # * SPDX-License-Identifier: Apache-2.0
 # ********************************************************************************/
+#
+# Run qemu with TAP network
+#
+# set -x 
 
-qemu-system-x86_64 \
- -device virtio-net-pci,netdev=net0,mac=52:54:00:12:35:02 \
- -netdev user,id=net0,hostfwd=tcp::2222-:22 \
- -object rng-random,filename=/dev/urandom,id=rng0 \
- -device virtio-rng-pci,rng=rng0 \
- -drive file=./build-sdv-x86_64/tmp/deploy/images/qemux86-64/sdv-image-all-qemux86-64-20220324170816.rootfs.ext4,if=virtio,format=raw \
- -usb \
- -device usb-tablet \
- -cpu IvyBridge \
- -machine q35 \
- -smp 4 \
- -m 2048 \
-# -serial mon:stdio \
- -serial null \
- -nographic \
- -kernel ./build-sdv-x86_64/tmp/deploy/images/qemux86-64/bzImage--5.14.21+git0+f9e349e174_9d5572038e-r0-qemux86-64-20220323081046.bin \
- -append "root=/dev/vda rw mem=2048M ip=dhcp console=ttyS0 console=ttyS1 oprofile.timer=1 tsc=reliable no_timer_check rcupdate.rcu_expedited=1"
+if [ -z "$1" ];
+then
+    echo "Usage: sudo $0 [1..5]"
+    exit 1;
+fi
+
+if [ "$EUID" -ne 0 ]
+  then echo "Please run as root"
+  exit
+fi
+
+
+INSTANCE="$1"
+
+TMPDIR="build/tmp"
+
+# Create overlays of the qcow2 files
+
+# Step 1 - delete existing, so we start from scratch
+#rm -f disk-instance-${INSTANCE}.qcow2
+#rm -f ovmf-instance-${INSTANCE}.qcow2
+
+# Step 2 - Create new disk overlays
+#$TMPDIR/work/x86_64-linux/qemu-helper-native/1.0-r1/recipe-sysroot-native/usr/bin/qemu-img create -F qcow2 -f qcow2 -b build/tmp/deploy/images/qemux86-64/sdv-image-all-qemux86-64.wic.qcow2 disk-instance-${INSTANCE}.qcow2
+#$TMPDIR/work/x86_64-linux/qemu-helper-native/1.0-r1/recipe-sysroot-native/usr/bin/qemu-img create -F qcow2 -f qcow2 -b build/tmp/deploy/images/qemux86-64/ovmf.qcow2 ovmf-instance-${INSTANCE}.qcow2
+
+$TMPDIR/work/x86_64-linux/qemu-helper-native/1.0-r1/recipe-sysroot-native/usr/bin/qemu-system-x86_64 \
+-device virtio-net-pci,netdev=net0,mac=52:54:00:12:34:0${INSTANCE} \
+-netdev tap,id=net0,ifname=tap${INSTANCE},script=no,downscript=no \
+-object rng-random,filename=/dev/urandom,id=rng0 \
+-device virtio-rng-pci,rng=rng0 \
+-drive id=hd,file=disk-instance-${INSTANCE}.qcow2,if=virtio,format=qcow2 \
+-enable-kvm \
+-serial mon:stdio \
+-serial null \
+-serial mon:vc \
+-nographic \
+-object can-bus,id=canbus0 \
+-device kvaser_pci,canbus=canbus0 \
+-drive if=pflash,format=qcow2,file=ovmf-instance-${INSTANCE}.qcow2 \
+-cpu IvyBridge \
+-machine q35 \
+-smp 4 \
+-m 4G

--- a/scripts/setup-taps.sh
+++ b/scripts/setup-taps.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+# /********************************************************************************
+# * Copyright (c) 2022 Contributors to the Eclipse Foundation
+# *
+# * See the NOTICE file(s) distributed with this work for additional
+# * information regarding copyright ownership.
+# *
+# * This program and the accompanying materials are made available under the
+# * terms of the Apache License 2.0 which is available at
+# * https://www.apache.org/licenses/LICENSE-2.0
+# *
+# * SPDX-License-Identifier: Apache-2.0
+# ********************************************************************************/
+#
+# Run qemu with TAP network
+#
+# set -x 
+
+if [ "$EUID" -ne 0 ]
+  then echo "Please run as root"
+  exit
+fi
+
+tunctl -g 1000 -t tap1
+tunctl -g 1000 -t tap2
+tunctl -g 1000 -t tap3
+tunctl -g 1000 -t tap4
+tunctl -g 1000 -t tap5
+
+ip addr add 192.168.7.101/32 broadcast 192.168.7.255 dev tap1
+ip addr add 192.168.7.102/32 broadcast 192.168.7.255 dev tap2
+ip addr add 192.168.7.103/32 broadcast 192.168.7.255 dev tap3
+ip addr add 192.168.7.104/32 broadcast 192.168.7.255 dev tap4
+ip addr add 192.168.7.105/32 broadcast 192.168.7.255 dev tap5
+
+ip link set dev tap1 up
+ip link set dev tap2 up
+ip link set dev tap3 up
+ip link set dev tap4 up
+ip link set dev tap5 up
+
+ip route add to 192.168.7.201/32 dev tap1
+ip route add to 192.168.7.202/32 dev tap2
+ip route add to 192.168.7.203/32 dev tap3
+ip route add to 192.168.7.204/32 dev tap4
+ip route add to 192.168.7.205/32 dev tap5
+
+iptables -A POSTROUTING -t nat -j MASQUERADE -s 192.168.7.101/32
+iptables -A POSTROUTING -t nat -j MASQUERADE -s 192.168.7.102/32
+iptables -A POSTROUTING -t nat -j MASQUERADE -s 192.168.7.103/32
+iptables -A POSTROUTING -t nat -j MASQUERADE -s 192.168.7.104/32
+iptables -A POSTROUTING -t nat -j MASQUERADE -s 192.168.7.105/32
+
+iptables -A POSTROUTING -t nat -j MASQUERADE -s 192.168.7.201/32
+iptables -A POSTROUTING -t nat -j MASQUERADE -s 192.168.7.202/32
+iptables -A POSTROUTING -t nat -j MASQUERADE -s 192.168.7.203/32
+iptables -A POSTROUTING -t nat -j MASQUERADE -s 192.168.7.204/32
+iptables -A POSTROUTING -t nat -j MASQUERADE -s 192.168.7.205/32
+
+echo 1 > /proc/sys/net/ipv4/ip_forward
+echo 1 > /proc/sys/net/ipv4/conf/tap1/proxy_arp
+echo 1 > /proc/sys/net/ipv4/conf/tap2/proxy_arp
+echo 1 > /proc/sys/net/ipv4/conf/tap3/proxy_arp
+echo 1 > /proc/sys/net/ipv4/conf/tap4/proxy_arp
+echo 1 > /proc/sys/net/ipv4/conf/tap5/proxy_arp
+
+iptables -P FORWARD ACCEPT


### PR DESCRIPTION
Added scripts and configurations for:
- Download Mirror
- Setup multiple TAP network interfaces on development host (Codespaces)
- Setup and run DHCP server on development host

To run multiple instances of the Leda image in QEMU on the development host (eg for testing networking, Some/IP etc.), we need to use multiple TAP network interfaces. The DHCP server running on the development host is for testing the default network configuration in the Leda distribution.

The default DHCP server configuration and the QEMU run script are using pre-defined IP addressed and the DHCP leases are using pre-defined MAC addresses for each instance (up to 5).
