### PR TITLE
Update DEV_DIR to point to manifests and remove initdir

### DIFF
--- a/kas/common-kirkstone.yaml
+++ b/kas/common-kirkstone.yaml
@@ -25,8 +25,7 @@ local_conf_header:
     INHERIT:remove = " archiver"
     INHERIT:remove = " cve-check"
     INHIBIT_PACKAGE_DEBUG_SPLIT = "1"
-    KANTO_MANIFESTS_DIR = "/data/var/containers/manifests"
-    KANTO_MANIFESTS_DEV_DIR = "/data/var/containers/manifests_dev"
+    KANTO_MANIFESTS_DEV_DIR = "/data/var/containers/manifests"
   rauc-sign-conf: |
     RAUC_KEYRING_FILE="${TOPDIR}/../examples/example-ca/ca.cert.pem"
     RAUC_KEY_FILE="${TOPDIR}/../examples/example-ca/private/development-1.key.pem"


### PR DESCRIPTION
See https://github.com/eclipse-leda/meta-leda/pull/151

KAD can now parse initdir and "internal state representation" manifests. It will take over the initdir functionality until the Kanto-CM native mechanism is stabilized.

This requires changing where there KANTO_MANIFESTS variables point to