### PR TITLE
Preparations 0.1.0 M1

### DIFF
--- a/.github/workflows/build-selfhosted.yml
+++ b/.github/workflows/build-selfhosted.yml
@@ -101,6 +101,15 @@ jobs:
         name: eclipse-leda-sbom-qemux86_64.tar.gz
         if-no-files-found: error
         path: eclipse-leda-sbom-qemux86_64.tar.gz
+    - name: Package Patched Sources
+      run: |
+        tar --create --gzip --file eclipse-leda-sources-qemux86_64.tar.gz -C ./build/tmp/deploy/sources/ .
+    - name: Upload files
+      uses: actions/upload-artifact@v3
+      with: 
+        name: eclipse-leda-sources-qemux86_64.tar.gz
+        if-no-files-found: error
+        path: eclipse-leda-sources-qemux86_64.tar.gz
     - uses: bacongobbler/azure-blob-storage-upload@v3.0.0
       if: github.repository_owner == 'SoftwareDefinedVehicle'
       with:
@@ -181,6 +190,15 @@ jobs:
         name: eclipse-leda-sbom-qemuarm64.tar.gz
         if-no-files-found: error
         path: eclipse-leda-sbom-qemuarm64.tar.gz
+    - name: Package Patched Sources
+      run: |
+        tar --create --gzip --file eclipse-leda-sources-qemuarm64.tar.gz -C ./build/tmp/deploy/sources/ .
+    - name: Upload files
+      uses: actions/upload-artifact@v3
+      with: 
+        name: eclipse-leda-sources-qemuarm64.tar.gz
+        if-no-files-found: error
+        path: eclipse-leda-sources-qemuarm64.tar.gz
     - uses: bacongobbler/azure-blob-storage-upload@v3.0.0
       if: github.repository_owner == 'SoftwareDefinedVehicle'
       with:
@@ -256,6 +274,15 @@ jobs:
         name: eclipse-leda-sbom-raspberrypi4-64.tar.gz
         if-no-files-found: error
         path: eclipse-leda-sbom-raspberrypi4-64.tar.gz
+    - name: Package Patched Sources
+      run: |
+        tar --create --gzip --file eclipse-leda-sources-raspberrypi4-64.tar.gz -C ./build/tmp/deploy/sources/ .
+    - name: Upload files
+      uses: actions/upload-artifact@v3
+      with: 
+        name: eclipse-leda-sources-raspberrypi4-64.tar.gz
+        if-no-files-found: error
+        path: eclipse-leda-sources-raspberrypi4-64.tar.gz
     - uses: bacongobbler/azure-blob-storage-upload@v3.0.0
       if: github.repository_owner == 'SoftwareDefinedVehicle'
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,6 +92,15 @@ jobs:
         name: eclipse-leda-sbom-qemux86_64.tar.gz
         if-no-files-found: error
         path: eclipse-leda-sbom-qemux86_64.tar.gz
+    - name: Package Patched Sources
+      run: |
+        tar --create --gzip --file eclipse-leda-sources-qemux86_64.tar.gz -C ./build/tmp/deploy/sources/ .
+    - name: Upload files
+      uses: actions/upload-artifact@v3
+      with: 
+        name: eclipse-leda-sources-qemux86_64.tar.gz
+        if-no-files-found: error
+        path: eclipse-leda-sources-qemux86_64.tar.gz
     - uses: bacongobbler/azure-blob-storage-upload@v3.0.0
       if: github.repository_owner == 'SoftwareDefinedVehicle'
       with:
@@ -172,6 +181,15 @@ jobs:
         name: eclipse-leda-sbom-qemuarm64.tar.gz
         if-no-files-found: error
         path: eclipse-leda-sbom-qemuarm64.tar.gz
+    - name: Package Patched Sources
+      run: |
+        tar --create --gzip --file eclipse-leda-sources-qemuarm64.tar.gz -C ./build/tmp/deploy/sources/ .
+    - name: Upload files
+      uses: actions/upload-artifact@v3
+      with: 
+        name: eclipse-leda-sources-qemuarm64.tar.gz
+        if-no-files-found: error
+        path: eclipse-leda-sources-qemuarm64.tar.gz
     - uses: bacongobbler/azure-blob-storage-upload@v3.0.0
       if: github.repository_owner == 'SoftwareDefinedVehicle'
       with:
@@ -248,6 +266,15 @@ jobs:
         name: eclipse-leda-sbom-raspberrypi4-64.tar.gz
         if-no-files-found: error
         path: eclipse-leda-sbom-raspberrypi4-64.tar.gz
+    - name: Package Patched Sources
+      run: |
+        tar --create --gzip --file eclipse-leda-sources-raspberrypi4-64.tar.gz -C ./build/tmp/deploy/sources/ .
+    - name: Upload files
+      uses: actions/upload-artifact@v3
+      with: 
+        name: eclipse-leda-sources-raspberrypi4-64.tar.gz
+        if-no-files-found: error
+        path: eclipse-leda-sources-raspberrypi4-64.tar.gz
     - uses: bacongobbler/azure-blob-storage-upload@v3.0.0
       if: github.repository_owner == 'SoftwareDefinedVehicle'
       with:

--- a/kas/common-kirkstone.yaml
+++ b/kas/common-kirkstone.yaml
@@ -22,8 +22,6 @@ target: sdv-image-all
 local_conf_header:
   meta-leda: |
     INHERIT += "rm_work"
-    INHERIT:remove = " archiver"
-    INHERIT:remove = " cve-check"
     INHIBIT_PACKAGE_DEBUG_SPLIT = "1"
     KANTO_MANIFESTS_DEV_DIR = "/data/var/containers/manifests"
   rauc-sign-conf: |
@@ -35,23 +33,23 @@ local_conf_header:
 repos:
   poky:
     url: "https://git.yoctoproject.org/git/poky"
-    refspec: kirkstone
+    refspec: 407c3e0237d947ec003bdd1af89a226121c7939c
     layers:
       meta:
       meta-poky:
       meta-yocto-bsp:
   meta-rauc:
     url: "https://github.com/rauc/meta-rauc.git"
-    refspec: kirkstone
+    refspec: 39e6f9387947c512148be09663476f59ff500c2b
   meta-kanto:
     url: "https://github.com/eclipse-kanto/meta-kanto.git"
-    refspec: kirkstone
+    refspec: 7d4067987321fbf274cf34b05415bb74a20abf52
   meta-virtualization:
     url: "https://git.yoctoproject.org/meta-virtualization"
-    refspec: kirkstone
+    refspec: bfa6727718bc4eb550c24e2c03a4118b4e7bc842
   meta-openembedded:
     url: "https://git.openembedded.org/meta-openembedded"
-    refspec: kirkstone
+    refspec: 571e36e20e9d1f27af0eb4545291beeb64f280e2
     layers:
       meta-oe:
       meta-filesystems:
@@ -59,10 +57,10 @@ repos:
       meta-networking:
   meta-spdxscanner:
     url: https://git.yoctoproject.org/meta-spdxscanner
-    refspec: kirkstone
+    refspec: 8b07df1535fe1203b07fc87f8c6a1e34311e2a1d
   meta-leda:
     url: "https://github.com/eclipse-leda/meta-leda"
-    refspec: main
+    refspec: baff5afa0014e1acba84758c01b88cfafbbe94e1
     layers:
       meta-leda-bsp:
       meta-leda-components:

--- a/kas/leda-qemux86-64.yaml
+++ b/kas/leda-qemux86-64.yaml
@@ -20,6 +20,6 @@ machine: qemux86-64
 repos:
   meta-rauc-community:
     url: "https://github.com/rauc/meta-rauc-community.git"
-    refspec: kirkstone
+    refspec: 7e626bdeb6b6e28c5f11c4af699df0742d258171
     layers:
       meta-rauc-qemux86:

--- a/kas/leda-raspberrypi4-64.yaml
+++ b/kas/leda-raspberrypi4-64.yaml
@@ -20,9 +20,9 @@ machine: raspberrypi4-64
 repos:
   meta-rauc-community:
     url: "https://github.com/rauc/meta-rauc-community.git"
-    refspec: kirkstone
+    refspec: 7e626bdeb6b6e28c5f11c4af699df0742d258171
     layers:
       meta-rauc-raspberrypi:
   meta-raspberrypi:
     url: "https://git.yoctoproject.org/meta-raspberrypi"
-    refspec: kirkstone
+    refspec: 2a06e4e84b04fc900f3a4524581548c9b5e57362


### PR DESCRIPTION
- Re-enable source archiver and cve-check for release builds
- Added packaging of (patched) sources to GitHub build workflows
- Locking down metalayers to specific commit hashes (for reproducable builds)