### PR TITLE
KAS Config TI Jacinto Arago

### DIFF
--- a/kas/more/ti-jacinto.yaml
+++ b/kas/more/ti-jacinto.yaml
@@ -1,0 +1,82 @@
+# /********************************************************************************
+# * Copyright (c) 2022 Contributors to the Eclipse Foundation
+# *
+# * See the NOTICE file(s) distributed with this work for additional
+# * information regarding copyright ownership.
+# *
+# * This program and the accompanying materials are made available under the
+# * terms of the Apache License 2.0 which is available at
+# * https://www.apache.org/licenses/LICENSE-2.0
+# *
+# * SPDX-License-Identifier: Apache-2.0
+# ********************************************************************************/
+# Every file needs to contain a header, that provides kas with information
+# about the context of this file.
+header:
+  version: 12
+machine: j721e-evm
+distro: arago
+target: core-image-minimal
+local_conf_header:
+  meta-leda: |
+    IMAGE_INSTALL += "packagegroup-sdv-core"
+    DISTRO_FEATURES += " sdv"
+    DISTRO_FEATURES += " rauc"
+    DISTRO_FEATURES += " virtualization"
+repos:
+  poky:
+    url: "https://git.yoctoproject.org/git/poky"
+    refspec: kirkstone
+    layers:
+      meta:
+      meta-poky:
+      meta-yocto-bsp:
+  meta-qt5:
+    url: https://github.com/meta-qt5/meta-qt5
+    refspec: kirkstone
+  meta-arm:
+    url: "https://git.yoctoproject.org/meta-arm/"
+    refspec: kirkstone
+    layers:
+      meta-arm:
+      meta-arm-bsp:
+      meta-arm-toolchain:
+  meta-ti:
+    url: "https://git.yoctoproject.org/meta-ti/"
+    refspec: kirkstone
+    layers:
+      meta-ti-bsp:
+      meta-ti-extras:
+  meta-arago:
+    url: "https://git.yoctoproject.org/meta-arago"
+    refspec: kirkstone
+    layers:
+      meta-arago-distro:
+      meta-arago-extras:
+  meta-rauc:
+    url: "https://github.com/rauc/meta-rauc.git"
+    refspec: kirkstone
+  meta-kanto:
+    url: "https://github.com/eclipse-kanto/meta-kanto.git"
+    refspec: kirkstone
+  meta-virtualization:
+    url: "https://git.yoctoproject.org/meta-virtualization"
+    refspec: kirkstone
+  meta-openembedded:
+    url: "https://git.openembedded.org/meta-openembedded"
+    refspec: kirkstone
+    layers:
+      meta-oe:
+      meta-filesystems:
+      meta-python:
+      meta-networking:
+  meta-leda:
+    url: "https://github.com/eclipse-leda/meta-leda"
+    refspec: main
+    layers:
+      meta-leda-components:
+  meta-rauc-community:
+    url: "https://github.com/rauc/meta-rauc-community.git"
+    refspec: kirkstone
+    layers:
+      meta-rauc-qemux86:


### PR DESCRIPTION
The KAS configuration for building Leda for the Texas Instruments Jacinto 7 based platform.
It's provided as an example as-is, but not officially tested / supported.