### PR TITLE
SBOM conversion from SPDX to CycloneDX for self-hosted builds

### DIFF
--- a/.github/workflow-scripts/sbom-converter.py
+++ b/.github/workflow-scripts/sbom-converter.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+import shutil
+import argparse
+import subprocess
+from pathlib import Path
+from multiprocessing.pool import ThreadPool as Pool
+
+
+def cyclonedx_cli_valid(cyclonedx_cli: Path) -> bool:
+    try:
+        s = subprocess.run(
+            [cyclonedx_cli], stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=False
+        )
+        stdout = s.stdout.decode("ascii")
+        return "cyclonedx" in stdout
+    except Exception as ex:
+        print(f"Cyclonedx cyclonedx_cli in {cyclonedx_cli} not valid:\n{ex}")
+        return False
+
+
+def get_cyclonedx_cli() -> Path:
+    """
+    Tries to find the CYCLONEDX_CLI, throws if it fails
+    """
+    cyclonedx_cli = os.getenv("CYCLONEDX_CLI")
+    if cyclonedx_cli is None:
+        # If variable is not set, try PATH
+        cyclonedx_cli = shutil.which("cyclonedx")
+    cyclonedx_cli = Path(cyclonedx_cli).resolve()
+    if not cyclonedx_cli_valid(cyclonedx_cli):
+        raise FileNotFoundError(
+            f"{cyclonedx_cli} not found or not functioning properly"
+        )
+    return cyclonedx_cli
+
+
+def convert_single_file(
+    cyclonedx_cli: Path, input_file_path: Path, output_file_path: Path
+) -> bool:
+    """Converts a single file from spdx.json to cyclonedx.json.
+    Returns true if the return code of cycleclonedx cli was 0, false otherwise"""
+    s = subprocess.run(
+        [
+            cyclonedx_cli,
+            "convert",
+            "--input-format",
+            "spdxjson",
+            "--output-format",
+            "json",
+            "--input-file",
+            input_file_path.resolve(),
+            "--output-file",
+            output_file_path.resolve(),
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    if s.returncode != 0:
+        print(s.stdout.decode("ascii"))
+        print(s.stderr.decode("ascii"))
+    return s.returncode == 0
+
+
+def convert_directory(
+    cyclonedx_cli: Path, input_directory: Path, output_directory: Path
+):
+    input_directory = input_directory.resolve()
+    if not input_directory.is_dir():
+        print(f"{input_directory} is not a valid directory")
+        sys.exit(2)
+
+    output_directory = output_directory.resolve()
+    if not output_directory.exists():
+        os.makedirs(output_directory)
+
+    def pool_task(spdx_file: Path):
+        new_name = spdx_file.name.replace(".spdx.json", ".json")
+        full_output_path = output_directory / new_name
+
+        if full_output_path.exists() and full_output_path.is_file():
+            print(f"Skipping {spdx_file} as it is already converted")
+            return True
+        convert_single_file(cyclonedx_cli, spdx_file, full_output_path)
+
+    spdx_files = input_directory.glob("*.spdx.json")
+    with Pool() as pool:
+        pool.map(pool_task, spdx_files)
+
+
+def cli_args():
+    parser = argparse.ArgumentParser(
+        prog="SBOM Converter",
+        description="Batch converts a directory containing SPDX files to CycloneDX format in parallel.",
+        epilog=(
+            "Uses the cyclonedx-cli as a base to convert single files.\
+        Requires the binary is either available in PATH as cyclonedx or the environmental variable CYCLONEDX_CLI to be set pointing to it.\
+        The cyclonedx binary can be downloaded from the official GitHub repository of the project: https://github.com/CycloneDX/cyclonedx-cli/releases."
+        ),
+    )
+    parser.add_argument(
+        "INPUT_DIR",
+        help="Directory containing the SPDX *.spdx.json files to be converted",
+        type=Path,
+    )
+    parser.add_argument(
+        "OUTPUT_DIR",
+        help="Directory where the converted CycloneDX *.json files will be saved",
+        type=Path,
+    )
+    return parser.parse_args()
+
+
+def main():
+    try:
+        cyclonedx_cli = get_cyclonedx_cli()
+    except Exception as ex:
+        print(ex)
+        print(
+            "cyclonedx binary not found. Please add it to PATH or set the "
+            "CYCLONEDX_CLI environmental variable with the correct path.\n"
+            "The binary for CycloneDX-cli can be found in the official releases:\n"
+            "https://github.com/CycloneDX/cyclonedx-cli/releases"
+        )
+        sys.exit(1)  # could not find cli, abort
+
+    args = cli_args()
+    convert_directory(cyclonedx_cli, args.INPUT_DIR, args.OUTPUT_DIR)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflow-scripts/sbom-converter.py
+++ b/.github/workflow-scripts/sbom-converter.py
@@ -1,5 +1,18 @@
 #!/usr/bin/env python3
 
+# /********************************************************************************
+# * Copyright (c) 2023 Contributors to the Eclipse Foundation
+# *
+# * See the NOTICE file(s) distributed with this work for additional
+# * information regarding copyright ownership.
+# *
+# * This program and the accompanying materials are made available under the
+# * terms of the Apache License 2.0 which is available at
+# * https://www.apache.org/licenses/LICENSE-2.0
+# *
+# * SPDX-License-Identifier: Apache-2.0
+# ********************************************************************************/
+
 import os
 import sys
 import shutil

--- a/.github/workflows/build-selfhosted.yml
+++ b/.github/workflows/build-selfhosted.yml
@@ -99,15 +99,15 @@ jobs:
         CYCLONEDX_CLI=./cyclonedx python3 ./.github/workflow-scripts/sbom-converter.py ./build/tmp/deploy/spdx/qemux86-64/runtime ./cyclonedx-sbom-qemux86/runtime
         CYCLONEDX_CLI=./cyclonedx python3 ./.github/workflow-scripts/sbom-converter.py ./build/tmp/deploy/spdx/qemux86-64/recipes ./cyclonedx-sbom-qemux86/recipes    
         CYCLONEDX_CLI=./cyclonedx python3 ./.github/workflow-scripts/sbom-converter.py ./build/tmp/deploy/spdx/qemux86-64/runtime ./cyclonedx-sbom-qemux86/runtime    
+    - name: Package CycloneDX SBOM
+      run: |
+        tar --create --gzip --file eclipse-leda-cyclonedx-sbom-qemux86_64.tar.gz -C ./cyclonedx-sbom-qemux86 .  
     - name: Upload CycloneDX SBOM
       uses: actions/upload-artifact@v3
       with: 
         name: eclipse-leda-cyclonedx-sbom-qemux86_64.tar.gz
         if-no-files-found: error
         path: eclipse-leda-cyclonedx-sbom-qemux86_64.tar.gz
-    - name: Package CycloneDX SBOM
-      run: |
-        tar --create --gzip --file eclipse-leda-cyclonedx-sbom-qemux86_64.tar.gz -C ./cyclonedx-sbom-qemux86 .  
     - name: Package SPDX files
       run: |
         tar --create --gzip --file eclipse-leda-sbom-qemux86_64.tar.gz -C ./build/tmp/deploy/spdx/qemux86-64/ .

--- a/.github/workflows/build-selfhosted.yml
+++ b/.github/workflows/build-selfhosted.yml
@@ -96,7 +96,7 @@ jobs:
       run: |
         wget -O cyclonedx https://github.com/CycloneDX/cyclonedx-cli/releases/download/v0.24.2/cyclonedx-linux-x64
         chmod +x ./cyclonedx
-        CYCLONEDX_CLI=./cyclonedx python3 ./workflow-scripts/sbom-converter.py ./build/tmp/deploy/spdx/qemux86-64/runtime ./cyclonedx-sbom/runtime    
+        CYCLONEDX_CLI=./cyclonedx python3 ./.github/workflow-scripts/sbom-converter.py ./build/tmp/deploy/spdx/qemux86-64/runtime ./cyclonedx-sbom/runtime    
     - name: Package SPDX files
       run: |
         tar --create --gzip --file eclipse-leda-sbom-qemux86_64.tar.gz -C ./build/tmp/deploy/spdx/qemux86-64/ .

--- a/.github/workflows/build-selfhosted.yml
+++ b/.github/workflows/build-selfhosted.yml
@@ -98,7 +98,7 @@ jobs:
         chmod +x ./cyclonedx
         CYCLONEDX_CLI=./cyclonedx python3 ./.github/workflow-scripts/sbom-converter.py ./build/tmp/deploy/spdx/qemux86-64/runtime ./cyclonedx-sbom-qemux86/runtime
         CYCLONEDX_CLI=./cyclonedx python3 ./.github/workflow-scripts/sbom-converter.py ./build/tmp/deploy/spdx/qemux86-64/recipes ./cyclonedx-sbom-qemux86/recipes    
-        CYCLONEDX_CLI=./cyclonedx python3 ./.github/workflow-scripts/sbom-converter.py ./build/tmp/deploy/spdx/qemux86-64/runtime ./cyclonedx-sbom-qemux86/runtime    
+        CYCLONEDX_CLI=./cyclonedx python3 ./.github/workflow-scripts/sbom-converter.py ./build/tmp/deploy/spdx/qemux86-64/packages ./cyclonedx-sbom-qemux86/packages    
     - name: Package CycloneDX SBOM
       run: |
         tar --create --gzip --file eclipse-leda-cyclonedx-sbom-qemux86_64.tar.gz -C ./cyclonedx-sbom-qemux86 .  
@@ -197,6 +197,22 @@ jobs:
         name: eclipse-leda-qemu-arm64.tar.xz
         if-no-files-found: error
         path: eclipse-leda-qemu-arm64.tar.xz
+    - name: Convert SPDX files to CycloneDX format
+      run: |
+        wget -nc -O cyclonedx https://github.com/CycloneDX/cyclonedx-cli/releases/download/v0.24.2/cyclonedx-linux-x64
+        chmod +x ./cyclonedx
+        CYCLONEDX_CLI=./cyclonedx python3 ./.github/workflow-scripts/sbom-converter.py ./build/tmp/deploy/spdx/qemuarm64/runtime ./cyclonedx-sbom-qemuarm64/runtime
+        CYCLONEDX_CLI=./cyclonedx python3 ./.github/workflow-scripts/sbom-converter.py ./build/tmp/deploy/spdx/qemuarm64/recipes ./cyclonedx-sbom-qemuarm64/recipes    
+        CYCLONEDX_CLI=./cyclonedx python3 ./.github/workflow-scripts/sbom-converter.py ./build/tmp/deploy/spdx/qemuarm64/packages ./cyclonedx-sbom-qemuarm64/packages    
+    - name: Package CycloneDX SBOM
+      run: |
+        tar --create --gzip --file eclipse-leda-cyclonedx-sbom-qemuarm64.tar.gz -C ./cyclonedx-sbom-qemuarm64 .  
+    - name: Upload CycloneDX SBOM
+      uses: actions/upload-artifact@v3
+      with: 
+        name: eclipse-leda-cyclonedx-sbom-qemuarm64.tar.gz
+        if-no-files-found: error
+        path: eclipse-leda-cyclonedx-sbom-qemuarm64.tar.gz
     - name: Package SPDX files
       run: |
         tar --create --gzip --file eclipse-leda-sbom-qemuarm64.tar.gz -C ./build/tmp/deploy/spdx/qemuarm64/ .
@@ -281,6 +297,22 @@ jobs:
         name: eclipse-leda-raspberrypi.tar.xz
         if-no-files-found: error
         path: eclipse-leda-raspberrypi.tar.xz
+    - name: Convert SPDX files to CycloneDX format
+      run: |
+        wget -nc -O cyclonedx https://github.com/CycloneDX/cyclonedx-cli/releases/download/v0.24.2/cyclonedx-linux-x64
+        chmod +x ./cyclonedx
+        CYCLONEDX_CLI=./cyclonedx python3 ./.github/workflow-scripts/sbom-converter.py ./build/tmp/deploy/spdx/raspberrypi4-64/runtime ./cyclonedx-sbom-raspberrypi4-64/runtime
+        CYCLONEDX_CLI=./cyclonedx python3 ./.github/workflow-scripts/sbom-converter.py ./build/tmp/deploy/spdx/raspberrypi4-64/recipes ./cyclonedx-sbom-raspberrypi4-64/recipes    
+        CYCLONEDX_CLI=./cyclonedx python3 ./.github/workflow-scripts/sbom-converter.py ./build/tmp/deploy/spdx/raspberrypi4-64/packages ./cyclonedx-sbom-raspberrypi4-64/packages    
+    - name: Package CycloneDX SBOM
+      run: |
+        tar --create --gzip --file eclipse-leda-cyclonedx-sbom-raspberrypi4-64.tar.gz -C ./cyclonedx-sbom-raspberrypi4-64 .  
+    - name: Upload CycloneDX SBOM
+      uses: actions/upload-artifact@v3
+      with: 
+        name: eclipse-leda-cyclonedx-sbom-raspberrypi4-64.tar.gz
+        if-no-files-found: error
+        path: eclipse-leda-cyclonedx-sbom-raspberrypi4-64.tar.gz
     - name: Package SPDX files
       run: |
         tar --create --gzip --file eclipse-leda-sbom-raspberrypi4-64.tar.gz -C ./build/tmp/deploy/spdx/raspberrypi4-64/ .

--- a/.github/workflows/build-selfhosted.yml
+++ b/.github/workflows/build-selfhosted.yml
@@ -99,18 +99,18 @@ jobs:
         CYCLONEDX_CLI=./cyclonedx python3 ./.github/workflow-scripts/sbom-converter.py ./build/tmp/deploy/spdx/qemux86-64/runtime ./cyclonedx-sbom-qemux86/runtime
         CYCLONEDX_CLI=./cyclonedx python3 ./.github/workflow-scripts/sbom-converter.py ./build/tmp/deploy/spdx/qemux86-64/recipes ./cyclonedx-sbom-qemux86/recipes    
         CYCLONEDX_CLI=./cyclonedx python3 ./.github/workflow-scripts/sbom-converter.py ./build/tmp/deploy/spdx/qemux86-64/runtime ./cyclonedx-sbom-qemux86/runtime    
-    - name: Package CycloneDX SBOM
-      run: |
-        tar --create --gzip --file eclipse-leda-cyclonedx-sbom-qemux86_64.tar.gz -C ./cyclonedx-sbom-qemux86 .  
-    - name: Package SPDX files
-      run: |
-        tar --create --gzip --file eclipse-leda-sbom-qemux86_64.tar.gz -C ./build/tmp/deploy/spdx/qemux86-64/ .
     - name: Upload CycloneDX SBOM
       uses: actions/upload-artifact@v3
       with: 
         name: eclipse-leda-cyclonedx-sbom-qemux86_64.tar.gz
         if-no-files-found: error
         path: eclipse-leda-cyclonedx-sbom-qemux86_64.tar.gz
+    - name: Package CycloneDX SBOM
+      run: |
+        tar --create --gzip --file eclipse-leda-cyclonedx-sbom-qemux86_64.tar.gz -C ./cyclonedx-sbom-qemux86 .  
+    - name: Package SPDX files
+      run: |
+        tar --create --gzip --file eclipse-leda-sbom-qemux86_64.tar.gz -C ./build/tmp/deploy/spdx/qemux86-64/ .
     - name: Upload SPDX SBOM
       uses: actions/upload-artifact@v3
       with: 

--- a/.github/workflows/build-selfhosted.yml
+++ b/.github/workflows/build-selfhosted.yml
@@ -113,13 +113,13 @@ jobs:
         path: eclipse-leda-cyclonedx-sbom-qemux86_64.tar.gz
     - name: Package SPDX files
       run: |
-        tar --create --gzip --file eclipse-leda-sbom-qemux86_64.tar.gz -C ./build/tmp/deploy/spdx/qemux86-64/ .
+        tar --create --gzip --file eclipse-leda-spdx-sbom-qemux86_64.tar.gz -C ./build/tmp/deploy/spdx/qemux86-64/ .
     - name: Upload SPDX SBOM
       uses: actions/upload-artifact@v3
       with: 
-        name: eclipse-leda-sbom-qemux86_64.tar.gz
+        name: eclipse-leda-spdx-sbom-qemux86_64.tar.gz
         if-no-files-found: error
-        path: eclipse-leda-sbom-qemux86_64.tar.gz
+        path: eclipse-leda-spdx-sbom-qemux86_64.tar.gz
     - name: Package Patched Sources
       run: |
         tar --create --gzip --file eclipse-leda-sources-qemux86_64.tar.gz -C ./build/tmp/deploy/sources/ .
@@ -221,13 +221,13 @@ jobs:
         path: eclipse-leda-cyclonedx-sbom-qemuarm64.tar.gz
     - name: Package SPDX files
       run: |
-        tar --create --gzip --file eclipse-leda-sbom-qemuarm64.tar.gz -C ./build/tmp/deploy/spdx/qemuarm64/ .
+        tar --create --gzip --file eclipse-leda-spdx-sbom-qemuarm64.tar.gz -C ./build/tmp/deploy/spdx/qemuarm64/ .
     - name: Upload files
       uses: actions/upload-artifact@v3
       with: 
-        name: eclipse-leda-sbom-qemuarm64.tar.gz
+        name: eclipse-leda-spdx-sbom-qemuarm64.tar.gz
         if-no-files-found: error
-        path: eclipse-leda-sbom-qemuarm64.tar.gz
+        path: eclipse-leda-spdx-sbom-qemuarm64.tar.gz
     - name: Package Patched Sources
       run: |
         tar --create --gzip --file eclipse-leda-sources-qemuarm64.tar.gz -C ./build/tmp/deploy/sources/ .
@@ -324,13 +324,13 @@ jobs:
         path: eclipse-leda-cyclonedx-sbom-raspberrypi4-64.tar.gz
     - name: Package SPDX files
       run: |
-        tar --create --gzip --file eclipse-leda-sbom-raspberrypi4-64.tar.gz -C ./build/tmp/deploy/spdx/raspberrypi4-64/ .
+        tar --create --gzip --file eclipse-leda-spdx-sbom-raspberrypi4-64.tar.gz -C ./build/tmp/deploy/spdx/raspberrypi4-64/ .
     - name: Upload files
       uses: actions/upload-artifact@v3
       with: 
-        name: eclipse-leda-sbom-raspberrypi4-64.tar.gz
+        name: eclipse-leda-spdx-sbom-raspberrypi4-64.tar.gz
         if-no-files-found: error
-        path: eclipse-leda-sbom-raspberrypi4-64.tar.gz
+        path: eclipse-leda-spdx-sbom-raspberrypi4-64.tar.gz
     - name: Package Patched Sources
       run: |
         tar --create --gzip --file eclipse-leda-sources-raspberrypi4-64.tar.gz -C ./build/tmp/deploy/sources/ .

--- a/.github/workflows/build-selfhosted.yml
+++ b/.github/workflows/build-selfhosted.yml
@@ -96,9 +96,11 @@ jobs:
       run: |
         wget -nc -O cyclonedx https://github.com/CycloneDX/cyclonedx-cli/releases/download/v0.24.2/cyclonedx-linux-x64
         chmod +x ./cyclonedx
-        CYCLONEDX_CLI=./cyclonedx python3 ./.github/workflow-scripts/sbom-converter.py ./build/tmp/deploy/spdx/qemux86-64/runtime ./cyclonedx-sbom-qemux86/runtime
-        CYCLONEDX_CLI=./cyclonedx python3 ./.github/workflow-scripts/sbom-converter.py ./build/tmp/deploy/spdx/qemux86-64/recipes ./cyclonedx-sbom-qemux86/recipes    
-        CYCLONEDX_CLI=./cyclonedx python3 ./.github/workflow-scripts/sbom-converter.py ./build/tmp/deploy/spdx/qemux86-64/packages ./cyclonedx-sbom-qemux86/packages    
+        python3 ./.github/workflow-scripts/sbom-converter.py ./build/tmp/deploy/spdx/qemux86-64/runtime ./cyclonedx-sbom-qemux86/runtime
+        python3 ./.github/workflow-scripts/sbom-converter.py ./build/tmp/deploy/spdx/qemux86-64/recipes ./cyclonedx-sbom-qemux86/recipes    
+        python3 ./.github/workflow-scripts/sbom-converter.py ./build/tmp/deploy/spdx/qemux86-64/packages ./cyclonedx-sbom-qemux86/packages    
+      env:
+        CYCLONEDX_CLI: ./cyclonedx 
     - name: Package CycloneDX SBOM
       run: |
         tar --create --gzip --file eclipse-leda-cyclonedx-sbom-qemux86_64.tar.gz -C ./cyclonedx-sbom-qemux86 .  
@@ -201,9 +203,11 @@ jobs:
       run: |
         wget -nc -O cyclonedx https://github.com/CycloneDX/cyclonedx-cli/releases/download/v0.24.2/cyclonedx-linux-x64
         chmod +x ./cyclonedx
-        CYCLONEDX_CLI=./cyclonedx python3 ./.github/workflow-scripts/sbom-converter.py ./build/tmp/deploy/spdx/qemuarm64/runtime ./cyclonedx-sbom-qemuarm64/runtime
-        CYCLONEDX_CLI=./cyclonedx python3 ./.github/workflow-scripts/sbom-converter.py ./build/tmp/deploy/spdx/qemuarm64/recipes ./cyclonedx-sbom-qemuarm64/recipes    
-        CYCLONEDX_CLI=./cyclonedx python3 ./.github/workflow-scripts/sbom-converter.py ./build/tmp/deploy/spdx/qemuarm64/packages ./cyclonedx-sbom-qemuarm64/packages    
+        python3 ./.github/workflow-scripts/sbom-converter.py ./build/tmp/deploy/spdx/qemuarm64/runtime ./cyclonedx-sbom-qemuarm64/runtime
+        python3 ./.github/workflow-scripts/sbom-converter.py ./build/tmp/deploy/spdx/qemuarm64/recipes ./cyclonedx-sbom-qemuarm64/recipes    
+        python3 ./.github/workflow-scripts/sbom-converter.py ./build/tmp/deploy/spdx/qemuarm64/packages ./cyclonedx-sbom-qemuarm64/packages
+      env:
+        CYCLONEDX_CLI: ./cyclonedx 
     - name: Package CycloneDX SBOM
       run: |
         tar --create --gzip --file eclipse-leda-cyclonedx-sbom-qemuarm64.tar.gz -C ./cyclonedx-sbom-qemuarm64 .  
@@ -301,9 +305,11 @@ jobs:
       run: |
         wget -nc -O cyclonedx https://github.com/CycloneDX/cyclonedx-cli/releases/download/v0.24.2/cyclonedx-linux-x64
         chmod +x ./cyclonedx
-        CYCLONEDX_CLI=./cyclonedx python3 ./.github/workflow-scripts/sbom-converter.py ./build/tmp/deploy/spdx/raspberrypi4-64/runtime ./cyclonedx-sbom-raspberrypi4-64/runtime
-        CYCLONEDX_CLI=./cyclonedx python3 ./.github/workflow-scripts/sbom-converter.py ./build/tmp/deploy/spdx/raspberrypi4-64/recipes ./cyclonedx-sbom-raspberrypi4-64/recipes    
-        CYCLONEDX_CLI=./cyclonedx python3 ./.github/workflow-scripts/sbom-converter.py ./build/tmp/deploy/spdx/raspberrypi4-64/packages ./cyclonedx-sbom-raspberrypi4-64/packages    
+        python3 ./.github/workflow-scripts/sbom-converter.py ./build/tmp/deploy/spdx/raspberrypi4-64/runtime ./cyclonedx-sbom-raspberrypi4-64/runtime
+        python3 ./.github/workflow-scripts/sbom-converter.py ./build/tmp/deploy/spdx/raspberrypi4-64/recipes ./cyclonedx-sbom-raspberrypi4-64/recipes    
+        python3 ./.github/workflow-scripts/sbom-converter.py ./build/tmp/deploy/spdx/raspberrypi4-64/packages ./cyclonedx-sbom-raspberrypi4-64/packages    
+      env:
+        CYCLONEDX_CLI: ./cyclonedx 
     - name: Package CycloneDX SBOM
       run: |
         tar --create --gzip --file eclipse-leda-cyclonedx-sbom-raspberrypi4-64.tar.gz -C ./cyclonedx-sbom-raspberrypi4-64 .  

--- a/.github/workflows/build-selfhosted.yml
+++ b/.github/workflows/build-selfhosted.yml
@@ -92,15 +92,26 @@ jobs:
         name: eclipse-leda-qemu-x86_64.tar.xz
         if-no-files-found: error
         path: eclipse-leda-qemu-x86_64.tar.xz
-    - name: Convert SPDX files
+    - name: Convert SPDX files to CycloneDX format
       run: |
-        wget -O cyclonedx https://github.com/CycloneDX/cyclonedx-cli/releases/download/v0.24.2/cyclonedx-linux-x64
+        wget -nc -O cyclonedx https://github.com/CycloneDX/cyclonedx-cli/releases/download/v0.24.2/cyclonedx-linux-x64
         chmod +x ./cyclonedx
-        CYCLONEDX_CLI=./cyclonedx python3 ./.github/workflow-scripts/sbom-converter.py ./build/tmp/deploy/spdx/qemux86-64/runtime ./cyclonedx-sbom/runtime    
+        CYCLONEDX_CLI=./cyclonedx python3 ./.github/workflow-scripts/sbom-converter.py ./build/tmp/deploy/spdx/qemux86-64/runtime ./cyclonedx-sbom-qemux86/runtime
+        CYCLONEDX_CLI=./cyclonedx python3 ./.github/workflow-scripts/sbom-converter.py ./build/tmp/deploy/spdx/qemux86-64/recipes ./cyclonedx-sbom-qemux86/recipes    
+        CYCLONEDX_CLI=./cyclonedx python3 ./.github/workflow-scripts/sbom-converter.py ./build/tmp/deploy/spdx/qemux86-64/runtime ./cyclonedx-sbom-qemux86/runtime    
+    - name: Package CycloneDX SBOM
+      run: |
+        tar --create --gzip --file eclipse-leda-cyclonedx-sbom-qemux86_64.tar.gz -C ./cyclonedx-sbom-qemux86 .  
     - name: Package SPDX files
       run: |
         tar --create --gzip --file eclipse-leda-sbom-qemux86_64.tar.gz -C ./build/tmp/deploy/spdx/qemux86-64/ .
-    - name: Upload files
+    - name: Upload CycloneDX SBOM
+      uses: actions/upload-artifact@v3
+      with: 
+        name: eclipse-leda-cyclonedx-sbom-qemux86_64.tar.gz
+        if-no-files-found: error
+        path: eclipse-leda-cyclonedx-sbom-qemux86_64.tar.gz
+    - name: Upload SPDX SBOM
       uses: actions/upload-artifact@v3
       with: 
         name: eclipse-leda-sbom-qemux86_64.tar.gz

--- a/.github/workflows/build-selfhosted.yml
+++ b/.github/workflows/build-selfhosted.yml
@@ -100,7 +100,8 @@ jobs:
         python3 ./.github/workflow-scripts/sbom-converter.py ./build/tmp/deploy/spdx/qemux86-64/recipes ./cyclonedx-sbom-qemux86/recipes    
         python3 ./.github/workflow-scripts/sbom-converter.py ./build/tmp/deploy/spdx/qemux86-64/packages ./cyclonedx-sbom-qemux86/packages    
       env:
-        CYCLONEDX_CLI: ./cyclonedx 
+        CYCLONEDX_CLI: ./cyclonedx
+        CONVERTER_LOG_LEVEL: INFO
     - name: Package CycloneDX SBOM
       run: |
         tar --create --gzip --file eclipse-leda-cyclonedx-sbom-qemux86_64.tar.gz -C ./cyclonedx-sbom-qemux86 .  
@@ -207,7 +208,8 @@ jobs:
         python3 ./.github/workflow-scripts/sbom-converter.py ./build/tmp/deploy/spdx/qemuarm64/recipes ./cyclonedx-sbom-qemuarm64/recipes    
         python3 ./.github/workflow-scripts/sbom-converter.py ./build/tmp/deploy/spdx/qemuarm64/packages ./cyclonedx-sbom-qemuarm64/packages
       env:
-        CYCLONEDX_CLI: ./cyclonedx 
+        CYCLONEDX_CLI: ./cyclonedx
+        CONVERTER_LOG_LEVEL: INFO
     - name: Package CycloneDX SBOM
       run: |
         tar --create --gzip --file eclipse-leda-cyclonedx-sbom-qemuarm64.tar.gz -C ./cyclonedx-sbom-qemuarm64 .  
@@ -309,7 +311,8 @@ jobs:
         python3 ./.github/workflow-scripts/sbom-converter.py ./build/tmp/deploy/spdx/raspberrypi4-64/recipes ./cyclonedx-sbom-raspberrypi4-64/recipes    
         python3 ./.github/workflow-scripts/sbom-converter.py ./build/tmp/deploy/spdx/raspberrypi4-64/packages ./cyclonedx-sbom-raspberrypi4-64/packages    
       env:
-        CYCLONEDX_CLI: ./cyclonedx 
+        CYCLONEDX_CLI: ./cyclonedx
+        CONVERTER_LOG_LEVEL: INFO
     - name: Package CycloneDX SBOM
       run: |
         tar --create --gzip --file eclipse-leda-cyclonedx-sbom-raspberrypi4-64.tar.gz -C ./cyclonedx-sbom-raspberrypi4-64 .  

--- a/.github/workflows/build-selfhosted.yml
+++ b/.github/workflows/build-selfhosted.yml
@@ -92,6 +92,11 @@ jobs:
         name: eclipse-leda-qemu-x86_64.tar.xz
         if-no-files-found: error
         path: eclipse-leda-qemu-x86_64.tar.xz
+    - name: Convert SPDX files
+      run: |
+        wget -O cyclonedx https://github.com/CycloneDX/cyclonedx-cli/releases/download/v0.24.2/cyclonedx-linux-x64
+        chmod +x ./cyclonedx
+        CYCLONEDX_CLI=./cyclonedx python3 ./workflow-scripts/sbom-converter.py ./build/tmp/deploy/spdx/qemux86-64/runtime ./cyclonedx-sbom/runtime    
     - name: Package SPDX files
       run: |
         tar --create --gzip --file eclipse-leda-sbom-qemux86_64.tar.gz -C ./build/tmp/deploy/spdx/qemux86-64/ .


### PR DESCRIPTION
# Issue

The CycloneDX format for the Software-Bill-Of-Materials (SBOM) is expected by tools like Dependency Track. Conversely, Yocto as a Linux-foundation-adjacent project only supports SPDX which is another SBOM format.

There exists a meta-layer for handling CycloneDX: https://github.com/bgnetworks/meta-dependencytrack which **only** supports Yocto Honister (older than the Kirkstone version targeted by meta-leda) and has not been updated in an year. That is why this option was not preffered

# Solution

CycloneDX provides a CLI which can convert a single *.spdx.json file to CycloneDX format that is rather slow to parse and convert said file. That is why a python script under ` .github/workflow-scripts/sbom-converter.py` was implemented which calls the CLI on an entire folder containing `*.spdx.json`-files in parallel to more efficiently convert the large SBOM for Leda-Distro (~50MBs of json files).

Since the operation of batch-converting the SPDX SBOM to CycloneDX is slow due to the large amount of files to be processed, the conversion step has been added only for self-hosted builds (`.github/workflows/build-selfhosted.yml`)