### PR TITLE
Update config to include meta-leda-backports layer

### DIFF
--- a/kas/common-kirkstone.yaml
+++ b/kas/common-kirkstone.yaml
@@ -61,9 +61,10 @@ repos:
     url: https://git.yoctoproject.org/meta-spdxscanner
     refspec: kirkstone
   meta-leda:
-    url: "https://github.com/eclipse-leda/meta-leda"
-    refspec: main
+    url: "https://github.com/SoftwareDefinedVehicle/meta-leda-fork.git"
+    refspec: meta-leda-backports
     layers:
       meta-leda-bsp:
       meta-leda-components:
       meta-leda-distro:
+      meta-leda-backports:

--- a/kas/common-kirkstone.yaml
+++ b/kas/common-kirkstone.yaml
@@ -61,8 +61,8 @@ repos:
     url: https://git.yoctoproject.org/meta-spdxscanner
     refspec: kirkstone
   meta-leda:
-    url: "https://github.com/SoftwareDefinedVehicle/meta-leda-fork.git"
-    refspec: meta-leda-backports
+    url: "https://github.com/eclipse-leda/meta-leda"
+    refspec: main
     layers:
       meta-leda-bsp:
       meta-leda-components:


### PR DESCRIPTION
meta-leda-components now depends on the backport of go 1.20, that's why we add it to the common-kirkstone.yaml kas-config