### PR TITLE
Leda for Ti Jacinto 7 example kas config

### DIFF
--- a/kas/more/leda-ti-jacinto7.yaml
+++ b/kas/more/leda-ti-jacinto7.yaml
@@ -20,7 +20,7 @@ target: sdv-image-all
 local_conf_header:
   user: |
     BBMASK .= "linux-ti-staging_6.1.bb|linux-ti-staging-rt_6.1.bb|linux-ti-staging-systest_6.1.bb"
-    IMAGE_FSTYPES += " tar.bz2 wic.bz2 wic.bmap ext4" 
+    IMAGE_FSTYPES:forcevariable := " tar.bz2 wic.bz2 wic.bmap ext4" 
     IMAGE_FSTYPES:remove = "ubi wic.qcow2"
     INHERIT:remove = "cve-check"
     WKS_FILE = "ti-dual-image.wks.in"

--- a/kas/more/leda-ti-jacinto7.yaml
+++ b/kas/more/leda-ti-jacinto7.yaml
@@ -1,5 +1,5 @@
 # /********************************************************************************
-# * Copyright (c) 2022 Contributors to the Eclipse Foundation
+# * Copyright (c) 2023 Contributors to the Eclipse Foundation
 # *
 # * See the NOTICE file(s) distributed with this work for additional
 # * information regarding copyright ownership.
@@ -20,8 +20,8 @@ target: sdv-image-all
 local_conf_header:
   user: |
     BBMASK .= "linux-ti-staging_6.1.bb|linux-ti-staging-rt_6.1.bb|linux-ti-staging-systest_6.1.bb"
-    IMAGE_FSTYPES:remove = "ubi"
-    IMAGE_FSTYPES = " wic.bz2 wic.bmap ext4 tar.gz"
+    IMAGE_FSTYPES += " tar.bz2 wic.bz2 wic.bmap ext4" 
+    IMAGE_FSTYPES:remove = "ubi wic.qcow2"
     INHERIT:remove = "cve-check"
     WKS_FILE = "ti-dual-image.wks.in"
   meta-leda: |

--- a/kas/more/leda-ti-jacinto7.yaml
+++ b/kas/more/leda-ti-jacinto7.yaml
@@ -48,6 +48,9 @@ repos:
       meta-filesystems:
       meta-python:
       meta-networking:
+  meta-lts-mixins:
+    url: "https://git.yoctoproject.org/git/meta-lts-mixins"
+    refspec: kirkstone/rust-1.68
   meta-arm:
     url: "https://git.yoctoproject.org/meta-arm/"
     refspec: kirkstone

--- a/kas/more/leda-ti-jacinto7.yaml
+++ b/kas/more/leda-ti-jacinto7.yaml
@@ -1,0 +1,84 @@
+# /********************************************************************************
+# * Copyright (c) 2022 Contributors to the Eclipse Foundation
+# *
+# * See the NOTICE file(s) distributed with this work for additional
+# * information regarding copyright ownership.
+# *
+# * This program and the accompanying materials are made available under the
+# * terms of the Apache License 2.0 which is available at
+# * https://www.apache.org/licenses/LICENSE-2.0
+# *
+# * SPDX-License-Identifier: Apache-2.0
+# ********************************************************************************/
+# Every file needs to contain a header, that provides kas with information
+# about the context of this file.
+header:
+  version: 12
+machine: j721e-evm
+distro: leda
+target: sdv-image-all
+local_conf_header:
+  user: |
+    BBMASK .= "linux-ti-staging_6.1.bb|linux-ti-staging-rt_6.1.bb|linux-ti-staging-systest_6.1.bb"
+    IMAGE_FSTYPES:remove = "ubi"
+    IMAGE_FSTYPES = " wic.bz2 wic.bmap ext4 tar.gz"
+    INHERIT:remove = "cve-check"
+    WKS_FILE = "ti-dual-image.wks.in"
+  meta-leda: |
+    INHERIT += "rm_work"
+    INHIBIT_PACKAGE_DEBUG_SPLIT = "1"
+    KANTO_MANIFESTS_DEV_DIR = "/data/var/containers/manifests"
+  rauc-sign-conf: |
+    RAUC_KEYRING_FILE="${TOPDIR}/../examples/example-ca/ca.cert.pem"
+    RAUC_KEY_FILE="${TOPDIR}/../examples/example-ca/private/development-1.key.pem"
+    RAUC_CERT_FILE="${TOPDIR}/../examples/example-ca/development-1.cert.pem"
+repos:
+  poky:
+    url: "https://git.yoctoproject.org/git/poky"
+    refspec: kirkstone
+    layers:
+      meta:
+      meta-poky:
+      meta-yocto-bsp:
+  meta-openembedded:
+    url: "https://git.openembedded.org/meta-openembedded"
+    refspec: kirkstone
+    layers:
+      meta-oe:
+      meta-filesystems:
+      meta-python:
+      meta-networking:
+  meta-arm:
+    url: "https://git.yoctoproject.org/meta-arm/"
+    refspec: kirkstone
+    layers:
+      meta-arm:
+      meta-arm-toolchain:
+  meta-ti:
+    url: "https://git.yoctoproject.org/meta-ti/"
+    refspec: kirkstone
+    layers:
+      meta-ti-bsp:
+      meta-ti-extras:
+  meta-rauc:
+    url: "https://github.com/rauc/meta-rauc.git"
+    refspec: kirkstone
+  meta-rauc-community:
+    url: "https://github.com/d-s-e/meta-rauc-community.git"
+    refspec: kirkstone-ti-support
+    layers:
+      meta-rauc-ti:
+  meta-virtualization:
+    url: "https://git.yoctoproject.org/meta-virtualization"
+    refspec: kirkstone
+  meta-kanto:
+    url: "https://github.com/eclipse-kanto/meta-kanto.git"
+    refspec: kirkstone
+  meta-leda:
+    url: "https://github.com/eclipse-leda/meta-leda"
+    refspec: main
+    layers:
+      meta-leda-bsp:
+      meta-leda-components:
+      meta-leda-distro:
+      meta-leda-backports:

--- a/kas/more/note_building_leda-ti-jacinto7.md
+++ b/kas/more/note_building_leda-ti-jacinto7.md
@@ -54,4 +54,4 @@ via the layer path for example:
 # Kikstart File
 
 This uses the default kickstart `wks.in` file from d-s-e's fork of meta-rauc-community. While this is sufficient for the
-purposes of the build you **should** define a `wks.in` similat to the RPI4-64B one in `meta-leda/meta-leda-distro/wic/raspberrypi.wks.in`.
+purposes of just building you **should** define a `wks.in` similar to the RPI4-64B one in `meta-leda/meta-leda-distro/wic/raspberrypi.wks.in`.

--- a/kas/more/note_building_leda-ti-jacinto7.md
+++ b/kas/more/note_building_leda-ti-jacinto7.md
@@ -51,7 +51,7 @@ via the layer path for example:
             meta-my-custom-layer:
 ```
 
-# Kikstart File
+# Kickstart File
 
 This uses the default kickstart `wks.in` file from d-s-e's fork of meta-rauc-community. While this is sufficient for the
 purposes of just building you **should** define a `wks.in` similar to the RPI4-64B one in `meta-leda/meta-leda-distro/wic/raspberrypi.wks.in`.

--- a/kas/more/note_building_leda-ti-jacinto7.md
+++ b/kas/more/note_building_leda-ti-jacinto7.md
@@ -50,3 +50,8 @@ via the layer path for example:
         layers:
             meta-my-custom-layer:
 ```
+
+# Kikstart File
+
+This uses the default kickstart `wks.in` file from d-s-e's fork of meta-rauc-community. While this is sufficient for the
+purposes of the build you **should** define a `wks.in` similat to the RPI4-64B one in `meta-leda/meta-leda-distro/wic/raspberrypi.wks.in`.

--- a/kas/more/note_building_leda-ti-jacinto7.md
+++ b/kas/more/note_building_leda-ti-jacinto7.md
@@ -1,0 +1,52 @@
+# Demo
+
+This kas file is provided only as an example for the TI-Jacinto platform. It only has been
+verified to build successfully (given that you follow the instructions in this note)
+without testing on actual hardware.
+
+# Arago
+
+We only use the base recipes from meta-ti in `leda-ti-jacinto7.yaml`, without depending on
+meta-arago which brings in unecessary changes for this demo kas-file.
+
+# Note on building on kernel version choise.
+
+On kirkstone there are two version of the Linux kernel provided - 6.1 and 5.10. 
+Kernel 6.1 seems to have problematic recipes, that's why in the
+kas-config the recipes `linux-ti-staging_6.1*.bb` are masked-out. This ensures 
+that BitBake will only pick up version 5.10 which seems stable/working.
+
+# Important!: Conntrack-netlink kernel module
+
+Kanto Container-Management requires the `kernel-module-nf-conntrack-netlink` 
+kernel module to be available as a runtime-dependency. This module is not however
+enable in the `linux-ti-staging*` kernel provided by meta-ti by default.
+
+In order to enable it (necessary for a successful build), in a custom meta-layer:
+
+1) Create the following append file `recipes-kernel/linux/linux-ti-staging_%.bbappend` containing:
+
+    ```shell
+    FILESEXTRAPATHS:prepend := "${THISDIR}/linux-ti-staging:"
+    SRC_URI:append = " file://netlink.cfg"
+
+
+    KERNEL_CONFIG_FRAGMENTS += " ${WORKDIR}/netlink.cfg"
+    ```
+
+2) Create the following config file `recipes-kernel/linux/linux-ti-staging/netlink.cfg` containing the single line:
+
+    ```shell
+    CONFIG_NF_CT_NETLINK=y
+    ```
+
+__Note__: If you are creating these files under a custom meta-layer you will have to add it to the `leda-ti-jacinto7.yaml` kas file
+via the layer path for example:
+
+```yaml
+    ...
+    meta-my-custom-layer:
+        path: <fs_path_to_layer_directory>
+        layers:
+            meta-my-custom-layer:
+```

--- a/kas/more/ti-jacinto.yaml
+++ b/kas/more/ti-jacinto.yaml
@@ -56,6 +56,9 @@ repos:
   meta-rauc:
     url: "https://github.com/rauc/meta-rauc.git"
     refspec: kirkstone
+  meta-lts-mixins:
+    url: "https://git.yoctoproject.org/git/meta-lts-mixins"
+    refspec: kirkstone/rust-1.68
   meta-kanto:
     url: "https://github.com/eclipse-kanto/meta-kanto.git"
     refspec: kirkstone

--- a/kas/more/ti-jacinto.yaml
+++ b/kas/more/ti-jacinto.yaml
@@ -74,6 +74,7 @@ repos:
     url: "https://github.com/eclipse-leda/meta-leda"
     refspec: main
     layers:
+      meta-leda-backports:
       meta-leda-components:
   meta-rauc-community:
     url: "https://github.com/rauc/meta-rauc-community.git"


### PR DESCRIPTION
Provide an example kas config how to build sdv-image-all (Leda quickstart image) for a TI jacinto based platform + a readme on kernel modules need to build kanto container management modules for that.