### PR TITLE
Add meta-lts-mixins to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,7 @@ meta-spdxscanner/
 meta-leda/
 meta-virtualization/
 poky/
+meta-lts-mixins/
 
 # Remote sstate-cache on Azure Storage
 azure-sstate-cache/


### PR DESCRIPTION
Meta-lts-mixins is now a meta-layer we use, so we should add it to .gitignore since it's fetched by kas every time.