### PR TITLE
Removed cve-check

### DIFF
--- a/kas/common-kirkstone.yaml
+++ b/kas/common-kirkstone.yaml
@@ -19,6 +19,7 @@ target: sdv-image-all
 local_conf_header:
   meta-leda: |
     INHERIT += "rm_work"
+    INHERIT:remove = " cve-check"
     INHIBIT_PACKAGE_DEBUG_SPLIT = "1"
     KANTO_MANIFESTS_DEV_DIR = "/data/var/containers/manifests"
   rauc-sign-conf: |


### PR DESCRIPTION
### Temporary removed cve-check

- The url that is used for cve-check database https://services.nvd.nist.gov is hardly reachable and non responsive (Error 503)