### PR TITLE
Remove from ort scan

### DIFF
--- a/.ort.yml
+++ b/.ort.yml
@@ -3,6 +3,8 @@ analyzer:
   skip_excluded: true
 excludes:
   paths:
+  - pattern: "resources/oss-compliance/aliens4friends/**"
+    reason: "BUILD_TOOL_OF"
   - pattern: "poky/bitbake/**"
     reason: "BUILD_TOOL_OF"
     comment: "Toaster is a web interface used to configure and run builds"


### PR DESCRIPTION
ORT fails with resolving a4f dependencies.

```
PIP failed to resolve dependencies for path 'resources/oss-compliance/aliens4friends/dockerfiles/requirements.txt': IOException: Running 'python-inspector --python-version 310 --operating-system linux --json-pdt /tmp/ort-PythonInspector13408373191109917864/python-inspector2844274467162666145.json --analyze-setup-py-insecurely --requirement /temp/resources/oss-compliance/aliens4friends/dockerfiles/requirements.txt --verbose' in '/temp/resources/oss-compliance/aliens4friends/dockerfiles' failed with exit code 1: <string>:67: RuntimeWarning: NumPy 1.19.5 may not yet support Python 3.10. Running from numpy source directory. <string>:480: UserWarning: Unrecognized setuptools command, proceeding with generating Cython sources and expanding templates Traceback (most recent call last): File "/temp/resources/oss-compliance/aliens4friends/dockerfiles/.cache/python_inspector/extracted_sdists/numpy-1.19.5/numpy-1.19.5/tools/cythonize.py", line 59, in process_pyx from Cython.Compiler.Version import version as cython_version ModuleNotFoundError: No module named 'Cython' During handling of the above exception, another exception occurred: Traceback (most recent call last): File "/temp/resources/oss-compliance/aliens4friends/dockerfiles/.cache/python_inspector/extracted_sdists/numpy-1.19.5/numpy-1.19.5/tools/cythonize.py", line 235, in <module> main() File "/temp/resources/oss-compliance/aliens4friends/dockerfiles/.cache/python_inspector/extracted_sdists/numpy-1.19.5/numpy-1.19.5/tools/cythonize.py", line 231, in main find_process_files(root_dir) File "/temp/resources/oss-compliance/aliens4friends/dockerfiles/.cache/python_inspector/extracted_sdists/numpy-1.19.5/numpy-1.19.5/tools/cythonize.py", line 222, in find_process_files process(root_dir, fromfile, tofile, function, hash_db) File "/temp/resources/oss-compliance/aliens4friends/dockerfiles/.cache/python_inspector/extracted_sdists/numpy-1.19.5/numpy-1.19.5/tools/cythonize.py", line 188, in process processor_function(fromfile, tofile) File "/temp/resources/oss-compliance/aliens4friends/dockerfiles/.cache/python_inspector/extracted_sdists/numpy-1.19.5/numpy-1.19.5/tools/cythonize.py", line 64, in process_pyx [...skipping 19 lines...] File "/usr/local/lib/python3.10/dist-packages/python_inspector/resolution.py", line 639, in get_dependencies return list(self._iter_dependencies(candidate)) File "/usr/local/lib/python3.10/dist-packages/python_inspector/resolution.py", line 630, in _iter_dependencies for r in self.get_requirements_for_package(purl=purl, candidate=candidate): File "/usr/local/lib/python3.10/dist-packages/python_inspector/resolution.py", line 509, in get_requirements_for_package_from_pypi_simple yield from get_requirements_from_python_manifest( File "/usr/local/lib/python3.10/dist-packages/python_inspector/resolution.py", line 299, in get_requirements_from_python_manifest yield from get_reqs_insecurely( File "/usr/local/lib/python3.10/dist-packages/python_inspector/resolution.py", line 277, in get_reqs_insecurely yield from parse_reqs_from_setup_py_insecurely(setup_py=setup_py_location) File "/usr/local/lib/python3.10/dist-packages/python_inspector/resolution.py", line 128, in parse_reqs_from_setup_py_insecurely for req in iter_requirements(level="", extras=[], setup_file=setup_py): File "/usr/local/lib/python3.10/dist-packages/python_inspector/setup_py_live_eval.py", line 117, in iter_requirements exec(file_contents, g) File "<string>", line 508, in <module> File "<string>", line 488, in setup_package File "<string>", line 285, in generate_cython RuntimeError: Running cythonize failed! (Above output is limited to each 20 heading and tailing lines.)
```

But since this is a compliance checking tool and not a direct dependency, the whole path is excluded from ort.yaml