### PR TITLE
Fix general release workflow issues

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,7 +47,7 @@ jobs:
       env:
         KAS_MACHINE: qemux86-64
       run: |
-        (r=3;while ! kas build kas/leda-qemux86-64.yaml:kas/mirrors.yaml ; do ((--r))||exit;sleep 60;done)
+        (r=3;while ! kas build kas/leda-qemux86-64.yaml:kas/mirrors.yaml:kas/oss-compliance/spdx.yaml ; do ((--r))||exit;sleep 60;done)
     - name: Generate CHANGELOG.md
       run: |
         docker run --rm -v "$(pwd)":/usr/local/src/your-app githubchangeloggenerator/github-changelog-generator github_changelog_generator -u eclipse-leda -p leda-distro --no-author -t ${{ secrets.GITHUB_TOKEN }}
@@ -136,8 +136,8 @@ jobs:
       env:
         KAS_MACHINE: qemuarm64
       run: |
-        (r=3;while ! kas build kas/leda-qemuarm64.yaml:kas/mirrors.yaml -- --setscene-only; do ((--r))||exit;sleep 60;done)
-        (r=3;while ! kas build kas/leda-qemuarm64.yaml:kas/mirrors.yaml ; do ((--r))||exit;sleep 60;done)
+        (r=3;while ! kas build kas/leda-qemuarm64.yaml:kas/mirrors.yaml:kas/oss-compliance/spdx.yaml -- --setscene-only; do ((--r))||exit;sleep 60;done)
+        (r=3;while ! kas build kas/leda-qemuarm64.yaml:kas/mirrors.yaml:kas/oss-compliance/spdx.yaml ; do ((--r))||exit;sleep 60;done)
     - name: Generate CHANGELOG.md
       run: |
         docker run --rm -v "$(pwd)":/usr/local/src/your-app githubchangeloggenerator/github-changelog-generator github_changelog_generator -u eclipse-leda -p leda-distro --no-author -t ${{ secrets.GITHUB_TOKEN }}
@@ -226,7 +226,7 @@ jobs:
       env:
         KAS_MACHINE: raspberrypi4-64
       run: |
-        (r=3;while ! kas build kas/leda-raspberrypi4-64.yaml:kas/mirrors.yaml ; do ((--r))||exit;sleep 60;done)
+        (r=3;while ! kas build kas/leda-raspberrypi4-64.yaml:kas/mirrors.yaml:kas/oss-compliance/spdx.yaml ; do ((--r))||exit;sleep 60;done)
     - name: Generate CHANGELOG.md
       run: |
         docker run --rm -v "$(pwd)":/usr/local/src/your-app githubchangeloggenerator/github-changelog-generator github_changelog_generator -u eclipse-leda -p leda-distro --no-author -t ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-selfhosted.yml
+++ b/.github/workflows/release-selfhosted.yml
@@ -45,9 +45,9 @@ jobs:
             ${{steps.download.outputs.download-path}}/eclipse-leda-qemu-x86_64.tar.xz/eclipse-leda-qemu-x86_64.tar.xz
             ${{steps.download.outputs.download-path}}/eclipse-leda-qemu-arm64.tar.xz/eclipse-leda-qemu-arm64.tar.xz
             ${{steps.download.outputs.download-path}}/eclipse-leda-raspberrypi.tar.xz/eclipse-leda-raspberrypi.tar.xz
-            ${{steps.download.outputs.download-path}}/eclipse-leda-sbom-qemu-x86_64.tar.gz/eclipse-leda-sbom-qemu-x86_64.tar.gz
-            ${{steps.download.outputs.download-path}}/eclipse-leda-sbom-qemu-arm64.tar.gz/eclipse-leda-sbom-qemu-arm64.tar.gz
-            ${{steps.download.outputs.download-path}}/eclipse-leda-sbom-raspberrypi.tar.gz/eclipse-leda-sbom-raspberrypi.tar.gz
-            ${{steps.download.outputs.download-path}}/eclipse-leda-sources-qemu-x86_64.tar.gz/eclipse-leda-sources-qemu-x86_64.tar.gz
+            ${{steps.download.outputs.download-path}}/eclipse-leda-spdx-sbom-qemu-x86_64.tar.gz/eclipse-leda-spdx-sbom-qemu-x86_64.tar.gz
+            ${{steps.download.outputs.download-path}}/eclipse-leda-spdx-sbom-qemu-arm64.tar.gz/eclipse-leda-spdx-sbom-qemu-arm64.tar.gz
+            ${{steps.download.outputs.download-path}}/eclipse-leda-spdx-sbom-raspberrypi.tar.gz/eclipse-leda-spdx-sbom-raspberrypi.tar.gz
+            ${{steps.download.outputs.download-path}}/eclipse-leda-sources-qemu-x86_64.tar.gz/eclipse-leda-sourcessources-qemu-x86_64.tar.gz
             ${{steps.download.outputs.download-path}}/eclipse-leda-sources-qemu-arm64.tar.gz/eclipse-leda-sources-qemu-arm64.tar.gz
             ${{steps.download.outputs.download-path}}/eclipse-leda-sources-raspberrypi.tar.gz/eclipse-leda-sources-raspberrypi.tar.gz

--- a/.github/workflows/release-selfhosted.yml
+++ b/.github/workflows/release-selfhosted.yml
@@ -45,9 +45,9 @@ jobs:
             ${{steps.download.outputs.download-path}}/eclipse-leda-qemu-x86_64.tar.xz/eclipse-leda-qemu-x86_64.tar.xz
             ${{steps.download.outputs.download-path}}/eclipse-leda-qemu-arm64.tar.xz/eclipse-leda-qemu-arm64.tar.xz
             ${{steps.download.outputs.download-path}}/eclipse-leda-raspberrypi.tar.xz/eclipse-leda-raspberrypi.tar.xz
-            ${{steps.download.outputs.download-path}}/eclipse-leda-spdx-sbom-qemu-x86_64.tar.gz/eclipse-leda-spdx-sbom-qemu-x86_64.tar.gz
-            ${{steps.download.outputs.download-path}}/eclipse-leda-spdx-sbom-qemu-arm64.tar.gz/eclipse-leda-spdx-sbom-qemu-arm64.tar.gz
-            ${{steps.download.outputs.download-path}}/eclipse-leda-spdx-sbom-raspberrypi.tar.gz/eclipse-leda-spdx-sbom-raspberrypi.tar.gz
-            ${{steps.download.outputs.download-path}}/eclipse-leda-sources-qemu-x86_64.tar.gz/eclipse-leda-sources-qemu-x86_64.tar.gz
-            ${{steps.download.outputs.download-path}}/eclipse-leda-sources-qemu-arm64.tar.gz/eclipse-leda-sources-qemu-arm64.tar.gz
-            ${{steps.download.outputs.download-path}}/eclipse-leda-sources-raspberrypi.tar.gz/eclipse-leda-sources-raspberrypi.tar.gz
+            ${{steps.download.outputs.download-path}}/eclipse-leda-spdx-sbom-qemux86_64.tar.gz/eclipse-leda-spdx-sbom-qemux86_64.tar.gz
+            ${{steps.download.outputs.download-path}}/eclipse-leda-spdx-sbom-qemuarm64.tar.gz/eclipse-leda-spdx-sbom-qemuarm64.tar.gz
+            ${{steps.download.outputs.download-path}}/eclipse-leda-spdx-sbom-raspberrypi4-64.tar.gz/eclipse-leda-spdx-sbom-raspberrypi4-64.tar.gz
+            ${{steps.download.outputs.download-path}}/eclipse-leda-sources-qemux86_64.tar.gz/eclipse-leda-sources-qemux86_64.tar.gz
+            ${{steps.download.outputs.download-path}}/eclipse-leda-sources-qemuarm64.tar.gz/eclipse-leda-sources-qemuarm64.tar.gz
+            ${{steps.download.outputs.download-path}}/eclipse-leda-sources-raspberrypi4-64.tar.gz/eclipse-leda-sources-raspberrypi4-64.tar.gz

--- a/.github/workflows/release-selfhosted.yml
+++ b/.github/workflows/release-selfhosted.yml
@@ -48,6 +48,6 @@ jobs:
             ${{steps.download.outputs.download-path}}/eclipse-leda-spdx-sbom-qemu-x86_64.tar.gz/eclipse-leda-spdx-sbom-qemu-x86_64.tar.gz
             ${{steps.download.outputs.download-path}}/eclipse-leda-spdx-sbom-qemu-arm64.tar.gz/eclipse-leda-spdx-sbom-qemu-arm64.tar.gz
             ${{steps.download.outputs.download-path}}/eclipse-leda-spdx-sbom-raspberrypi.tar.gz/eclipse-leda-spdx-sbom-raspberrypi.tar.gz
-            ${{steps.download.outputs.download-path}}/eclipse-leda-sources-qemu-x86_64.tar.gz/eclipse-leda-sourcessources-qemu-x86_64.tar.gz
+            ${{steps.download.outputs.download-path}}/eclipse-leda-sources-qemu-x86_64.tar.gz/eclipse-leda-sources-qemu-x86_64.tar.gz
             ${{steps.download.outputs.download-path}}/eclipse-leda-sources-qemu-arm64.tar.gz/eclipse-leda-sources-qemu-arm64.tar.gz
             ${{steps.download.outputs.download-path}}/eclipse-leda-sources-raspberrypi.tar.gz/eclipse-leda-sources-raspberrypi.tar.gz

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,9 +43,9 @@ jobs:
             ${{steps.download.outputs.download-path}}/eclipse-leda-qemu-x86_64.tar.xz/eclipse-leda-qemu-x86_64.tar.xz
             ${{steps.download.outputs.download-path}}/eclipse-leda-qemu-arm64.tar.xz/eclipse-leda-qemu-arm64.tar.xz
             ${{steps.download.outputs.download-path}}/eclipse-leda-raspberrypi.tar.xz/eclipse-leda-raspberrypi.tar.xz
-            ${{steps.download.outputs.download-path}}/eclipse-leda-spdx-sbom-qemux86_64.tar.gz/eclipse-leda-spdx-sbom-qemux86_64.tar.gz
-            ${{steps.download.outputs.download-path}}/eclipse-leda-spdx-sbom-qemuarm64.tar.gz/eclipse-leda-spdx-sbom-qemuarm64.tar.gz
-            ${{steps.download.outputs.download-path}}/eclipse-leda-spdx-sbom-raspberrypi4-64.tar.gz/eclipse-leda-spdx-sbom-raspberrypi4-64.tar.gz
+            ${{steps.download.outputs.download-path}}/eclipse-leda-sbom-qemux86_64.tar.gz/eclipse-leda-sbom-qemux86_64.tar.gz
+            ${{steps.download.outputs.download-path}}/eclipse-leda-sbom-qemuarm64.tar.gz/eclipse-leda-sbom-qemuarm64.tar.gz
+            ${{steps.download.outputs.download-path}}/eclipse-leda-sbom-raspberrypi4-64.tar.gz/eclipse-leda-sbom-raspberrypi4-64.tar.gz
             ${{steps.download.outputs.download-path}}/eclipse-leda-sources-qemux86_64.tar.gz/eclipse-leda-sources-qemux86_64.tar.gz
             ${{steps.download.outputs.download-path}}/eclipse-leda-sources-qemuarm64.tar.gz/eclipse-leda-sources-qemuarm64.tar.gz
             ${{steps.download.outputs.download-path}}/eclipse-leda-sources-raspberrypi4-64.tar.gz/eclipse-leda-sources-raspberrypi4-64.tar.gz

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,9 +43,9 @@ jobs:
             ${{steps.download.outputs.download-path}}/eclipse-leda-qemu-x86_64.tar.xz/eclipse-leda-qemu-x86_64.tar.xz
             ${{steps.download.outputs.download-path}}/eclipse-leda-qemu-arm64.tar.xz/eclipse-leda-qemu-arm64.tar.xz
             ${{steps.download.outputs.download-path}}/eclipse-leda-raspberrypi.tar.xz/eclipse-leda-raspberrypi.tar.xz
-            ${{steps.download.outputs.download-path}}/eclipse-leda-spdx-sbom-qemu-x86_64.tar.gz/eclipse-leda-spdx-sbom-qemu-x86_64.tar.gz
-            ${{steps.download.outputs.download-path}}/eclipse-leda-spdx-sbom-qemu-arm64.tar.gz/eclipse-leda-spdx-sbom-qemu-arm64.tar.gz
-            ${{steps.download.outputs.download-path}}/eclipse-leda-spdx-sbom-raspberrypi.tar.gz/eclipse-leda-spdx-sbom-raspberrypi.tar.gz
-            ${{steps.download.outputs.download-path}}/eclipse-leda-sources-qemu-x86_64.tar.gz/eclipse-leda-sources-qemu-x86_64.tar.gz
-            ${{steps.download.outputs.download-path}}/eclipse-leda-sources-qemu-arm64.tar.gz/eclipse-leda-sources-qemu-arm64.tar.gz
-            ${{steps.download.outputs.download-path}}/eclipse-leda-sources-raspberrypi.tar.gz/eclipse-leda-sources-raspberrypi.tar.gz
+            ${{steps.download.outputs.download-path}}/eclipse-leda-spdx-sbom-qemux86_64.tar.gz/eclipse-leda-spdx-sbom-qemux86_64.tar.gz
+            ${{steps.download.outputs.download-path}}/eclipse-leda-spdx-sbom-qemuarm64.tar.gz/eclipse-leda-spdx-sbom-qemuarm64.tar.gz
+            ${{steps.download.outputs.download-path}}/eclipse-leda-spdx-sbom-raspberrypi4-64.tar.gz/eclipse-leda-spdx-sbom-raspberrypi4-64.tar.gz
+            ${{steps.download.outputs.download-path}}/eclipse-leda-sources-qemux86_64.tar.gz/eclipse-leda-sources-qemux86_64.tar.gz
+            ${{steps.download.outputs.download-path}}/eclipse-leda-sources-qemuarm64.tar.gz/eclipse-leda-sources-qemuarm64.tar.gz
+            ${{steps.download.outputs.download-path}}/eclipse-leda-sources-raspberrypi4-64.tar.gz/eclipse-leda-sources-raspberrypi4-64.tar.gz

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,9 +43,9 @@ jobs:
             ${{steps.download.outputs.download-path}}/eclipse-leda-qemu-x86_64.tar.xz/eclipse-leda-qemu-x86_64.tar.xz
             ${{steps.download.outputs.download-path}}/eclipse-leda-qemu-arm64.tar.xz/eclipse-leda-qemu-arm64.tar.xz
             ${{steps.download.outputs.download-path}}/eclipse-leda-raspberrypi.tar.xz/eclipse-leda-raspberrypi.tar.xz
-            ${{steps.download.outputs.download-path}}/eclipse-leda-sbom-qemu-x86_64.tar.gz/eclipse-leda-sbom-qemu-x86_64.tar.gz
-            ${{steps.download.outputs.download-path}}/eclipse-leda-sbom-qemu-arm64.tar.gz/eclipse-leda-sbom-qemu-arm64.tar.gz
-            ${{steps.download.outputs.download-path}}/eclipse-leda-sbom-raspberrypi.tar.gz/eclipse-leda-sbom-raspberrypi.tar.gz
+            ${{steps.download.outputs.download-path}}/eclipse-leda-spdx-sbom-qemu-x86_64.tar.gz/eclipse-leda-spdx-sbom-qemu-x86_64.tar.gz
+            ${{steps.download.outputs.download-path}}/eclipse-leda-spdx-sbom-qemu-arm64.tar.gz/eclipse-leda-spdx-sbom-qemu-arm64.tar.gz
+            ${{steps.download.outputs.download-path}}/eclipse-leda-spdx-sbom-raspberrypi.tar.gz/eclipse-leda-spdx-sbom-raspberrypi.tar.gz
             ${{steps.download.outputs.download-path}}/eclipse-leda-sources-qemu-x86_64.tar.gz/eclipse-leda-sources-qemu-x86_64.tar.gz
             ${{steps.download.outputs.download-path}}/eclipse-leda-sources-qemu-arm64.tar.gz/eclipse-leda-sources-qemu-arm64.tar.gz
             ${{steps.download.outputs.download-path}}/eclipse-leda-sources-raspberrypi.tar.gz/eclipse-leda-sources-raspberrypi.tar.gz


### PR DESCRIPTION
With time the build/release workflows have gotten out of sync with the actual names of artifacts, kas files, etc. This PR brings them up to date.

A successful release with those can be found here:
https://github.com/SoftwareDefinedVehicle/leda-distro-fork/releases/tag/test-0.1.0-M2-VUM