### PR TITLE
Update manager robot test

### DIFF
--- a/resources/docker-snapshot/dockerfiles/leda-tests/10__containers.robot
+++ b/resources/docker-snapshot/dockerfiles/leda-tests/10__containers.robot
@@ -33,7 +33,6 @@ SDV Containers Exist
     Verify Leda Containers
     ...     sua
     ...     databroker
-    ...     vum
     ...     feedercan
     ...     seatservice-example
     ...     hvacservice-example

--- a/resources/docker-snapshot/dockerfiles/leda-tests/40__update_manager.robot
+++ b/resources/docker-snapshot/dockerfiles/leda-tests/40__update_manager.robot
@@ -30,7 +30,9 @@ ${get_state_filename}       robot-resources/get_state.json
 ${topic_pub_desiredstate}   vehicleupdate/desiredstate
 ${desired_state_no_containers_filename}     robot-resources/desired-state-no-containers.json
 ${desired_state_filename}                   robot-resources/desired-state.json
-@{containers}           databroker    feedercan    seatservice-example    hvacservice-example
+@{containers}             sua    feedercan    seatservice-example    databroker    hvacservice-example
+@{any_state_containers}   cloudconnector
+@{stop_containers}        seatservice-example    databroker    feedercan    hvacservice-example
 
 *** Test Cases ***
 
@@ -38,16 +40,20 @@ Check containers running
   [Documentation]    Check containers running
   Wait Until Keyword Succeeds  5m  3s  Verify SUA is alive  ${broker.uri}  ${broker.port}  ${topic_pub_currentstate}  ${topic_sub_currentstate}  ${get_state_filename}  ${sua_alive_regex}
   ${result}=     Check containers status  ${broker.uri}  ${broker.port}  Running  @{containers}
-  Should Be Empty    ${result}
+  Should Be Empty    ${result}    msg=Container(s) ${result} must be Running
+  ${result}=     Check containers status  ${broker.uri}  ${broker.port}  Any  @{any_state_containers}
+  Should Be Empty    ${result}    msg=Container(s) ${result} must persist
 
 Stop containers
   [Documentation]    Stop containers
   Publish command from file    ${broker.uri}    ${broker.port}    ${topic_pub_desiredstate}    ${desired_state_no_containers_filename}
-  ${result}=     Check containers status  ${broker.uri}  ${broker.port}  Stopped  @{containers}
-  Should Be Empty    ${result}
+  ${result}=     Check containers status  ${broker.uri}  ${broker.port}  Stopped  @{stop_containers}
+  Should Be Empty    ${result}    msg=Container(s) ${result} must be Stopped
 
 Bring all containers running
   [Documentation]    Bring all containers running
   Publish command from file    ${broker.uri}    ${broker.port}    ${topic_pub_desiredstate}    ${desired_state_filename}
   ${result}=     Check containers status  ${broker.uri}  ${broker.port}  Running  @{containers}
-  Should Be Empty    ${result}
+  Should Be Empty    ${result}    msg=Container(s) ${result} must be Running
+  ${result}=     Check containers status  ${broker.uri}  ${broker.port}  Any  @{any_state_containers}
+  Should Be Empty    ${result}    msg=Container(s) ${result} must persist

--- a/resources/docker-snapshot/dockerfiles/leda-tests/40__update_manager.robot
+++ b/resources/docker-snapshot/dockerfiles/leda-tests/40__update_manager.robot
@@ -30,7 +30,7 @@ ${get_state_filename}       robot-resources/get_state.json
 ${topic_pub_desiredstate}   vehicleupdate/desiredstate
 ${desired_state_no_containers_filename}     robot-resources/desired-state-no-containers.json
 ${desired_state_filename}                   robot-resources/desired-state.json
-@{containers}               seatservice-example    hvacservice-example    databroker    feedercan
+@{containers}           databroker    feedercan    seatservice-example    hvacservice-example
 
 *** Test Cases ***
 

--- a/resources/docker-snapshot/dockerfiles/leda-tests/40__update_manager.robot
+++ b/resources/docker-snapshot/dockerfiles/leda-tests/40__update_manager.robot
@@ -1,0 +1,58 @@
+# /********************************************************************************
+# * Copyright (c) 2023 Contributors to the Eclipse Foundation
+# *
+# * See the NOTICE file(s) distributed with this work for additional
+# * information regarding copyright ownership.
+# *
+# * This program and the accompanying materials are made available under the
+# * terms of the Apache License 2.0 which is available at
+# * https://www.apache.org/licenses/LICENSE-2.0
+# *
+# * SPDX-License-Identifier: Apache-2.0
+# ********************************************************************************/
+
+*** Settings ***
+Documentation     Update Manager ${leda.target}
+Resource          leda_keywords.resource
+
+Library  OperatingSystem
+Library  Process
+
+Test Timeout       10 minutes
+
+*** Variables ***
+#${leda.target}                 local
+#${leda.target.hostname}        localhost
+#${leda.sshport}                2001
+
+#${broker.uri}               127.0.0.1
+#${broker.port}              1884
+${sua_alive_regex}           ([.\\s\\S]*)("self-update-agent")([\\s\\S.]*)
+${topic_pub_currentstate}   selfupdate/currentstate/get
+${topic_sub_currentstate}   selfupdate/currentstate
+${get_state_filename}       robot-resources/get_state.json
+
+${topic_pub_desiredstate}   vehicleupdate/desiredstate
+${desired_state_no_containers_filename}     robot-resources/desired-state-no-containers.json
+${desired_state_filename}                   robot-resources/desired-state.json
+@{containers}               seatservice-example   hvacservice-example   databroker   feedercan
+
+*** Test Cases ***
+
+Check containers running
+  [Documentation]    Check containers running
+  Wait Until Keyword Succeeds  5m  3s  Verify SUA is alive  ${broker.uri}  ${broker.port}  ${topic_pub_currentstate}  ${topic_sub_currentstate}  ${get_state_filename}  ${sua_alive_regex}
+  ${result}=     Check containers status  ${broker.uri}  ${broker.port}  Running  @{containers}
+  Should Be Empty    ${result}
+
+Stop containers
+  [Documentation]    Stop containers
+  Publish command from file    ${broker.uri}    ${broker.port}    ${topic_pub_desiredstate}    ${desired_state_no_containers_filename}
+  ${result}=     Check containers status  ${broker.uri}  ${broker.port}  Stopped  @{containers}
+  Should Be Empty    ${result}
+
+Bring all containers running
+  [Documentation]    Bring all containers running
+  Publish command from file    ${broker.uri}    ${broker.port}    ${topic_pub_desiredstate}    ${desired_state_filename}
+  ${result}=     Check containers status  ${broker.uri}  ${broker.port}  Running  @{containers}
+  Should Be Empty    ${result}

--- a/resources/docker-snapshot/dockerfiles/leda-tests/40__update_manager.robot
+++ b/resources/docker-snapshot/dockerfiles/leda-tests/40__update_manager.robot
@@ -21,12 +21,7 @@ Library  Process
 Test Timeout       10 minutes
 
 *** Variables ***
-#${leda.target}                 local
-#${leda.target.hostname}        localhost
-#${leda.sshport}                2001
 
-#${broker.uri}               127.0.0.1
-#${broker.port}              1884
 ${sua_alive_regex}           ([.\\s\\S]*)("self-update-agent")([\\s\\S.]*)
 ${topic_pub_currentstate}   selfupdate/currentstate/get
 ${topic_sub_currentstate}   selfupdate/currentstate
@@ -35,7 +30,7 @@ ${get_state_filename}       robot-resources/get_state.json
 ${topic_pub_desiredstate}   vehicleupdate/desiredstate
 ${desired_state_no_containers_filename}     robot-resources/desired-state-no-containers.json
 ${desired_state_filename}                   robot-resources/desired-state.json
-@{containers}               seatservice-example   hvacservice-example   databroker   feedercan
+@{containers}               seatservice-example    hvacservice-example    databroker    feedercan
 
 *** Test Cases ***
 

--- a/resources/docker-snapshot/dockerfiles/leda-tests/leda_keywords.resource
+++ b/resources/docker-snapshot/dockerfiles/leda-tests/leda_keywords.resource
@@ -16,6 +16,7 @@ Documentation     This is a resource file, that can contain variables and keywor
 ...               Keywords defined here can be used where this file is loaded.
 
 Library  MQTTLibrary
+Library  JSONLibrary
 Library  yaml
 Library  Collections
 Library  OperatingSystem
@@ -24,6 +25,7 @@ Library  String
 
 *** Variables ***
 ${leda.sshport}                    2222
+${json_query}     $..payload[*].softwareNodes[?(@.id=='containers:{container}')].parameters[?(@.key=='status')].value
 
 *** Keywords ***
 
@@ -58,6 +60,11 @@ Execute SUA command
   ${message}=      Get File  ${filename}
   Publish Single  topic=${topic_pub}  payload=${message}  hostname=${broker.uri}  port=${broker.port}
   
+Publish command from file
+  [Arguments]    ${broker.uri}    ${broker.port}    ${topic_pub}    ${filename}
+  ${message}=      Get File  ${filename}
+  Publish Single  topic=${topic_pub}  payload=${message}  hostname=${broker.uri}  port=${broker.port}
+
 Connect and Subscribe to Listen
   [Arguments]    ${broker.uri}    ${broker.port}    ${topic_sub}    ${payload_regex}    ${message_wait_timeout_seconds}
   Connect  ${broker.uri}  ${broker.port}
@@ -119,3 +126,38 @@ Leda Execute
     Log    ${result.stdout}
     Log    ${result.stderr}
     RETURN    ${result}
+
+Check containers status
+    [Documentation]    Checks list of containers for status (Running and Stopped)
+    [Arguments]    ${broker.uri}    ${broker.port}   ${status}   @{list}
+    Connect    ${broker.uri}    ${broker.port} 
+    @{listNext}      Create List    @{list}
+    TRY
+      WHILE   ${listNext} != @{EMPTY}   limit=50
+        Publish command from file    ${broker.uri}    ${broker.port}
+        ...   containersupdate/currentstate/get
+        ...   robot-resources/update-state.json
+        @{messagelist}=   Subscribe   containersupdate/currentstate   qos=0   timeout=70    limit=1
+        Length should be  ${messagelist}   1
+        ${json_string}=       Get From List   ${messagelist}    0
+        ${message}=	      Convert String to JSON	   ${json_string}
+        @{listCurrent}   Create List    @{listNext}
+        FOR    ${container}    IN    @{listCurrent}
+          ${jq}=    Format String  ${json_query}
+          ...    container=${container}
+          ${result}=     Get Value From Json    ${message}    ${jq}
+          IF  ${result} == @{EMPTY}   
+            CONTINUE
+          END
+          Length should be  ${result}   1
+          ${result}=       Get From List   ${result}    0
+          IF   '${result}' == '${status}'
+            Remove values from list    ${listNext}   ${container}
+          END
+        END
+      END
+    EXCEPT    WHILE loop was aborted    type=start
+      Log    The loop did not finish within the limit.
+    END   
+    Disconnect
+    RETURN    ${listNext}

--- a/resources/docker-snapshot/dockerfiles/leda-tests/leda_keywords.resource
+++ b/resources/docker-snapshot/dockerfiles/leda-tests/leda_keywords.resource
@@ -128,33 +128,36 @@ Leda Execute
     RETURN    ${result}
 
 Check containers status
-    [Documentation]    Checks list of containers for status (Running and Stopped)
+    [Documentation]    Checks list of containers for status (Running, Stopped and Any)
     [Arguments]    ${broker.uri}    ${broker.port}   ${status}   @{list}
     Connect    ${broker.uri}    ${broker.port} 
     @{listNext}      Create List    @{list}
     TRY
-      WHILE   ${listNext} != @{EMPTY}   limit=50
+      WHILE   ${listNext} != @{EMPTY}   limit=100
         Publish command from file    ${broker.uri}    ${broker.port}
         ...   containersupdate/currentstate/get
         ...   robot-resources/update-state.json
-        @{messagelist}=   Subscribe   containersupdate/currentstate   qos=0   timeout=90    limit=1
+        @{messagelist}=   Subscribe   containersupdate/currentstate   qos=1   timeout=50    limit=1
         Length should be  ${messagelist}   1
-        ${json_string}=       Get From List   ${messagelist}    0
+        ${json_string}=   Get From List   ${messagelist}    0
         ${message}=	      Convert String to JSON	   ${json_string}
-        @{listCurrent}   Create List    @{listNext}
+        @{listCurrent}    Create List    @{listNext}
         FOR    ${container}    IN    @{listCurrent}
           ${jq}=    Format String  ${json_query}
           ...    container=${container}
-          ${result}=     Get Value From Json    ${message}    ${jq}
+          ${result}=      Get Value From Json    ${message}    ${jq}
           IF  ${result} == @{EMPTY}   
             CONTINUE
           END
           Length should be  ${result}   1
-          ${result}=       Get From List   ${result}    0
-          IF   '${result}' == '${status}'
+          ${result}=      Get From List   ${result}    0
+          IF       '${result}' == '${status}'
+            Remove values from list    ${listNext}   ${container}
+          ELSE IF  '${status}' == 'Any'
             Remove values from list    ${listNext}   ${container}
           END
         END
+        Unsubscribe     containersupdate/currentstate
       END
     EXCEPT    WHILE loop was aborted    type=start
       Log    The loop did not finish within the limit.

--- a/resources/docker-snapshot/dockerfiles/leda-tests/leda_keywords.resource
+++ b/resources/docker-snapshot/dockerfiles/leda-tests/leda_keywords.resource
@@ -137,7 +137,7 @@ Check containers status
         Publish command from file    ${broker.uri}    ${broker.port}
         ...   containersupdate/currentstate/get
         ...   robot-resources/update-state.json
-        @{messagelist}=   Subscribe   containersupdate/currentstate   qos=0   timeout=70    limit=1
+        @{messagelist}=   Subscribe   containersupdate/currentstate   qos=0   timeout=90    limit=1
         Length should be  ${messagelist}   1
         ${json_string}=       Get From List   ${messagelist}    0
         ${message}=	      Convert String to JSON	   ${json_string}

--- a/resources/docker-snapshot/dockerfiles/leda-tests/robot-resources/desired-state-no-containers.json
+++ b/resources/docker-snapshot/dockerfiles/leda-tests/robot-resources/desired-state-no-containers.json
@@ -1,0 +1,12 @@
+{
+	"activityId": "activity-id-no-containers",
+	"payload": {
+		"domains": [{
+			"id": "containers",
+			"config": [],
+			"components": [
+
+			]
+		}]
+	}
+}

--- a/resources/docker-snapshot/dockerfiles/leda-tests/robot-resources/desired-state.json
+++ b/resources/docker-snapshot/dockerfiles/leda-tests/robot-resources/desired-state.json
@@ -1,0 +1,387 @@
+{
+  "activityId": "activity-id-leda-containers",
+  "payload": {
+    "domains": [
+      {
+        "id": "containers",
+        "config": [],
+        "components": [
+          {
+            "id": "databroker",
+            "version": "0.3.0",
+            "config": [
+              {
+                "key": "image",
+                "value": "ghcr.io/eclipse/kuksa.val/databroker:0.3.0"
+              },
+              {
+                "key": "env",
+                "value": "RUST_LOG=info"
+              },
+              {
+                "key": "env",
+                "value": "vehicle_data_broker=debug"
+              },
+              {
+                "key": "privileged",
+                "value": "false"
+              },
+              {
+                "key": "network",
+                "value": "bridge"
+              },
+              {
+                "key": "port",
+                "value": "localhost:55555:30555-30555/tcp"
+              },
+              {
+                "key": "restartPolicy",
+                "value": "unless-stopped"
+              },
+              {
+                "key": "restartMaxRetries",
+                "value": "0"
+              },
+              {
+                "key": "restartTimeout",
+                "value": "0"
+              },
+              {
+                "key": "logDriver",
+                "value": "json-file"
+              },
+              {
+                "key": "logMaxFiles",
+                "value": "2"
+              },
+              {
+                "key": "logMaxSize",
+                "value": "1M"
+              },
+              {
+                "key": "logMode",
+                "value": "blocking"
+              },
+              {
+                "key": "terminal",
+                "value": "false"
+              },
+              {
+                "key": "interactive",
+                "value": "false"
+              }
+            ]
+          },
+          {
+            "id": "feedercan",
+            "version": "v0.1.1",
+            "config": [
+              {
+                "key": "image",
+                "value": "ghcr.io/eclipse/kuksa.val.feeders/dbc2val:v0.1.1"
+              },
+              {
+                "key": "env",
+                "value": "VEHICLEDATABROKER_DAPR_APP_ID=databroker"
+              },
+              {
+                "key": "env",
+                "value": "VDB_ADDRESS=databroker:55555"
+              },
+              {
+                "key": "env",
+                "value": "USECASE=databroker"
+              },
+              {
+                "key": "env",
+                "value": "LOG_LEVEL=info"
+              },
+              {
+                "key": "env",
+                "value": "databroker=info"
+              },
+              {
+                "key": "env",
+                "value": "broker_client=info"
+              },
+              {
+                "key": "env",
+                "value": "dbcfeeder=info"
+              },
+              {
+                "key": "privileged",
+                "value": "false"
+              },
+              {
+                "key": "network",
+                "value": "bridge"
+              },
+              {
+                "key": "host",
+                "value": "databroker:container_databroker-host"
+              },
+              {
+                "key": "restartPolicy",
+                "value": "unless-stopped"
+              },
+              {
+                "key": "restartMaxRetries",
+                "value": "0"
+              },
+              {
+                "key": "restartTimeout",
+                "value": "0"
+              },
+              {
+                "key": "logDriver",
+                "value": "json-file"
+              },
+              {
+                "key": "logMaxFiles",
+                "value": "2"
+              },
+              {
+                "key": "logMaxSize",
+                "value": "1M"
+              },
+              {
+                "key": "logMode",
+                "value": "blocking"
+              },
+              {
+                "key": "terminal",
+                "value": "false"
+              },
+              {
+                "key": "interactive",
+                "value": "false"
+              }
+            ]
+          },
+          {
+            "id": "hvacservice-example",
+            "version": "v0.1.0",
+            "config": [
+              {
+                "key": "image",
+                "value": "ghcr.io/eclipse/kuksa.val.services/hvac_service:v0.1.0"
+              },
+              {
+                "key": "env",
+                "value": "VEHICLEDATABROKER_DAPR_APP_ID=databroker"
+              },
+              {
+                "key": "env",
+                "value": "VDB_ADDRESS=databroker:55555"
+              },
+              {
+                "key": "privileged",
+                "value": "false"
+              },
+              {
+                "key": "network",
+                "value": "bridge"
+              },
+              {
+                "key": "host",
+                "value": "databroker:container_databroker-host"
+              },
+              {
+                "key": "restartPolicy",
+                "value": "unless-stopped"
+              },
+              {
+                "key": "restartMaxRetries",
+                "value": "0"
+              },
+              {
+                "key": "restartTimeout",
+                "value": "0"
+              },
+              {
+                "key": "logDriver",
+                "value": "json-file"
+              },
+              {
+                "key": "logMaxFiles",
+                "value": "2"
+              },
+              {
+                "key": "logMaxSize",
+                "value": "1M"
+              },
+              {
+                "key": "logMode",
+                "value": "blocking"
+              },
+              {
+                "key": "terminal",
+                "value": "false"
+              },
+              {
+                "key": "interactive",
+                "value": "false"
+              }
+            ]
+          },
+          {
+            "id": "seatservice-example",
+            "version": "v0.3.0",
+            "config": [
+              {
+                "key": "image",
+                "value": "ghcr.io/boschglobal/kuksa.val.services/seat_service:v0.3.0"
+              },
+              {
+                "key": "env",
+                "value": "BROKER_ADDR=databroker:55555"
+              },
+              {
+                "key": "env",
+                "value": "RUST_LOG=info"
+              },
+              {
+                "key": "env",
+                "value": "vehicle_data_broker=info"
+              },
+              {
+                "key": "privileged",
+                "value": "false"
+              },
+              {
+                "key": "network",
+                "value": "bridge"
+              },
+              {
+                "key": "port",
+                "value": "localhost:50051:30051-30051/tcp"
+              },
+              {
+                "key": "host",
+                "value": "databroker:container_databroker-host"
+              },
+              {
+                "key": "restartPolicy",
+                "value": "unless-stopped"
+              },
+              {
+                "key": "restartMaxRetries",
+                "value": "0"
+              },
+              {
+                "key": "restartTimeout",
+                "value": "0"
+              },
+              {
+                "key": "logDriver",
+                "value": "json-file"
+              },
+              {
+                "key": "logMaxFiles",
+                "value": "2"
+              },
+              {
+                "key": "logMaxSize",
+                "value": "1M"
+              },
+              {
+                "key": "logMode",
+                "value": "blocking"
+              }
+            ]
+          },
+          {
+            "id": "cloudconnector",
+            "version": "main-47c01227a620a3dbd85b66e177205c06c0f7a52e",
+            "config": [
+              {
+                "key": "image",
+                "value": "ghcr.io/eclipse-leda/leda-contrib-cloud-connector/cloudconnector:main-47c01227a620a3dbd85b66e177205c06c0f7a52e"
+              },
+              {
+                "key": "mount",
+                "value": "/data/var/certificates/device.crt:/device.crt:rprivate"
+              },
+              {
+                "key": "mount",
+                "value": "/data/var/certificates/device.key:/device.key:rprivate"
+              },
+              {
+                "key": "env",
+                "value": "CERT_FILE=/device.crt"
+              },
+              {
+                "key": "env",
+                "value": "KEY_FILE=/device.key"
+              },
+              {
+                "key": "env",
+                "value": "LOCAL_ADDRESS=tcp://mosquitto:1883"
+              },
+              {
+                "key": "env",
+                "value": "LOG_FILE="
+              },
+              {
+                "key": "env",
+                "value": "LOG_LEVEL=INFO"
+              },
+              {
+                "key": "env",
+                "value": "CA_CERT_PATH=/app/iothub.crt"
+              },
+              {
+                "key": "env",
+                "value": "MESSAGE_MAPPER_CONFIG=/app/message-mapper-config.json"
+              },
+              {
+                "key": "env",
+                "value": "ALLOWED_LOCAL_TOPICS_LIST=cloudConnector/#"
+              },
+              {
+                "key": "privileged",
+                "value": "false"
+              },
+              {
+                "key": "network",
+                "value": "bridge"
+              },
+              {
+                "key": "host",
+                "value": "mosquitto:host_ip"
+              },
+              {
+                "key": "restartPolicy",
+                "value": "unless-stopped"
+              },
+              {
+                "key": "restartMaxRetries",
+                "value": "0"
+              },
+              {
+                "key": "restartTimeout",
+                "value": "0"
+              },
+              {
+                "key": "logDriver",
+                "value": "json-file"
+              },
+              {
+                "key": "logMaxFiles",
+                "value": "2"
+              },
+              {
+                "key": "logMaxSize",
+                "value": "1M"
+              },
+              {
+                "key": "logMode",
+                "value": "blocking"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/resources/docker-snapshot/dockerfiles/leda-tests/robot-resources/update-state.json
+++ b/resources/docker-snapshot/dockerfiles/leda-tests/robot-resources/update-state.json
@@ -1,0 +1,5 @@
+{
+    "activityId": "update-state",
+    "timestamp": 123456789,
+    "payload": {}
+ }


### PR DESCRIPTION
### Starts and stops containers using desired state and Update Manager (UM)

1. Wait all containers to start
2. Sends desired state json to UM to stop all containers
3. Sends desired state json to UM to start again all containers

Upon each step the containers are checked for appropriate status (Started or Stopped)

- As _vum_ is no longer persists as container but is implemanted as UM service, it was not included in this test (40__update_manager.robot) and also removed from 10__containers.robot
